### PR TITLE
β調整による管理効果を比較する表を一括画像保存する関数を追加 (#2)

### DIFF
--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -1,0 +1,31 @@
+context("Utilities")
+
+test_that("pull single table from table list", {
+  # pull_var_from_kobeII_table() is not tested yet
+  expect_equal(1, 1)
+})
+
+test_that("convert table from kobeIItable to the required format", {
+  before <- data.frame(beta = c(1, 0.5, 0),
+                       y2019 = seq(12345, 11234, length.out = 3),
+                       y2020 = seq(22345, 12345, length.out = 3),
+                       y2021 = seq(32345, 23456, length.out = 3))
+
+  after_raw <- format_beta_table(before, divide_by = 1)
+  expect_equal(after_raw[, 1], c(1, 0.5, 0))
+  expect_equal(after_raw[, "y2019"], c(12345, 11790, 11234))
+  expect_equal(after_raw[, "y2020"], c(22345, 17345, 12345))
+  expect_equal(after_raw[, "y2021"], c(32345, 27900, 23456))
+
+  after_ton <- format_beta_table(before, divide_by = 1000, round = FALSE)
+  expect_equal(after_ton[, 1], c(1, 0.5, 0))
+  expect_equal(after_ton[, "y2019"], c(12.345, 11.790, 11.234), tolerance = 5e-4)
+  expect_equal(after_ton[, "y2020"], c(22.345, 17.345, 12.345), tolerance = 5e-4)
+  expect_equal(after_ton[, "y2021"], c(32.345, 27.900, 23.456), tolerance = 5e-4)
+
+  after_ton_rounded <- format_beta_table(before, divide_by = 1000, round = TRUE)
+  expect_equal(after_ton_rounded[, 1], c(1, 0.5, 0))
+  expect_equal(after_ton_rounded[, "y2019"], c(12, 12, 11))
+  expect_equal(after_ton_rounded[, "y2020"], c(22, 17, 12))
+  expect_equal(after_ton_rounded[, "y2021"], c(32, 28, 23))
+})


### PR DESCRIPTION
# できるようになること

```
export_kobeII_tables(kobeII.table)
```
すると，以下4つの表の画像が作業ディレクトリに書き出されます
- 親魚量が「目標」管理基準値を上回る確率
- 親魚量が「限界」管理基準値を上回る確率
- 「親魚量」の予測平均値
- 「漁獲量」の予測平均値

画像サンプル
![tbl_ssb](https://user-images.githubusercontent.com/14845847/68638760-e02ab900-0545-11ea-98d9-ad32b9961e5b.png)

## 応用
任意の名前で任意のディレクトリに保存もできますが，以下のような愚直な実装です

```
export_kobeII_tables <- function(kobeII_table,
                                 fname_ssb = "tbl_ssb.png",
                                 fname_catch = "tbl_catch.png",
                                 fname_ssb_above_target = "tbl_ssb>target.png",
                                 fname_ssb_above_limit = "tbl_ssb>limit.png") {
```

## メモ
https://github.com/akikirinrin/frasyr/pull/2/commits/f6e9d6a925405a183064e27697544eaa56abbf80
はテストを書くべきと思うのですが，kobeII.table の作り方がいまいちわかっていなくて，テストを書けませんでした．

よろしくお願いします．

Fix #106 