### PR TITLE
fix prof.lik #125 and convert_vpa_tibble #108

### DIFF
--- a/R/stock_recruit.r
+++ b/R/stock_recruit.r
@@ -419,12 +419,12 @@ boot.SR <- function(Res,n=100,seed=1){
 }
 
 #'  profile likelihood
-#' 
+#' @param Res 再生産関係（\code{fit.SR()}）の結果オブジェクト
 #' @encoding UTF-8
 #' @export
 #' 
 
-prof.lik <- function(Res,a=Res$pars$a,b=Res$pars$b,sd=Res$pars$sd,rho=Res$pars$rho) {
+prof.lik <- function(Res,a=Res$pars$a,b=Res$pars$b,sd=Res$pars$sd,rho=ifelse(Res$input$out.AR,0,Res$pars$rho)) {
   SRdata <- Res$input$SRdata
   rec <- SRdata$R
   ssb <- SRdata$SSB

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -96,7 +96,11 @@ convert_vector <- function(vector,name){
 
 convert_vpa_tibble <- function(vpares){
 
+  if (is.null(vpares$input$dat$waa.catch)) {
+    total.catch <- colSums(vpares$input$dat$caa*vpares$input$dat$waa,na.rm=T)
+  } else {
     total.catch <- colSums(vpares$input$dat$caa*vpares$input$dat$waa.catch,na.rm=T)
+  }
     U <- total.catch/colSums(vpares$baa)
 
     SSB <- convert_vector(colSums(vpares$ssb,na.rm=T),"SSB") %>%

--- a/man/SRregime_plot.Rd
+++ b/man/SRregime_plot.Rd
@@ -5,14 +5,12 @@
 \alias{SRregime_plot}
 \title{fit.SRregimeの結果で得られた再生産関係をプロットするための関数}
 \usage{
-SRregime_plot(resSRregime, xscale = 1000, xlabel = "SSB", yscale = 1,
-  ylabel = "R", labeling.year = NULL, show.legend = TRUE,
-  legend.title = "Regime", regime.name = NULL, base_size = 16,
-  add.info = TRUE)
+SRregime_plot(SRregime_result, xscale = 1000, xlabel = "SSB",
+  yscale = 1, ylabel = "R", labeling.year = NULL,
+  show.legend = TRUE, legend.title = "Regime", regime.name = NULL,
+  base_size = 16, add.info = TRUE)
 }
 \arguments{
-\item{resSRregime}{\code{fit.SRregime}の結果}
-
 \item{xscale}{X軸のスケーリングの値（親魚量をこの値で除す）}
 
 \item{xlabel}{X軸のラベル}
@@ -32,6 +30,8 @@ SRregime_plot(resSRregime, xscale = 1000, xlabel = "SSB", yscale = 1,
 \item{base_size}{\code{ggplot}のベースサイズ}
 
 \item{add.info}{\code{AICc}や\code{regime.year}, \code{regime.key}などの情報を加えるかどうか}
+
+\item{resSRregime}{\code{fit.SRregime}の結果}
 
 \item{use.fit.SR}{パラメータの初期値を決めるのに\code{frasyr::fit.SR}を使う（時間の短縮になる）}
 }

--- a/man/prof.lik.Rd
+++ b/man/prof.lik.Rd
@@ -6,7 +6,10 @@
 \title{profile likelihood}
 \usage{
 prof.lik(Res, a = Res$pars$a, b = Res$pars$b, sd = Res$pars$sd,
-  rho = Res$pars$rho)
+  rho = ifelse(Res$input$out.AR, 0, Res$pars$rho))
+}
+\arguments{
+\item{Res}{再生産関係（\code{fit.SR()}）の結果オブジェクト}
 }
 \description{
 profile likelihood


### PR DESCRIPTION
- 再生産関係のプロファイル尤度の関数prof.lik()がout.ARに対応していなかったので修正 #125 
- convert_vpa_tibble()がvpaのinputでwaa.catchがNULLだとエラーが出るようになっちゃってたので（たぶん #108）修正しました。

会議資料の作成時にdevを開発してdevで計算するってのは結果が急に再現できなくなって焦るのでできれば避けたいです。ブランチ運用を再検討すべきかとも思いますが、今回は計算ミスではなく、単純なエラーだったので、単純なエラーチェックのためのテストコードも至急必要なのではないかと思います。