### PR TITLE
#161

### DIFF
--- a/vignettes/estMSY.Rmd
+++ b/vignettes/estMSY.Rmd
@@ -65,7 +65,6 @@ SRmodel.base <- SR.list[[1]] # AIC最小モデルを今後使っていく
 
 
 # currentFによる将来予測
->>>>>>> 07acd67cd1b870e640bfc8cb56065a43521ba244
 - 細かい設定の解説は[こちら](https://ichimomo.github.io/frasyr/docs/future.html)
     - 自己相関を考慮する場合
     - Frecオプション（目標の年に指定した確率で漁獲する）


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47109605/70844887-f43a4100-1e8a-11ea-9380-3dbe8c800ec1.png)
https://github.com/ichimomo/frasyr/issues/81 で触れたましたが、Rstudio上でvignettesを読めるようになります。マークダウンが一部おかしくなっていたので修正します。

コミットのIDだと思います。コンフリクト( https://github.com/ichimomo/frasyr/issues/39 )を解消する際に残ってしまったものかと。私もRuby on Railsのスキーマファイルでたまに同じことをやります。。

今回の修正以前に、devtools::check()が通らないところがあるのですが、他のかたも同様の問題が起きていますか？(テストは問題なく通っています)。普段はrubyやjavascriptを書いているのもあり、何か見落としがあれば教えていただけると幸いです(諸々読んでみたのですがコレというのが見つからず。。)。場合によって切り分けてIssueに出します。こういうのが整ったら、テストコードなどのリファクタリングを出して行こうかなと思います。

```
#' @inheritParams draw_SRline' in current package
 parse(text = x) でエラー: <text>:1:1:  想定外の入力です 
1: \
    ^
```