### PR TITLE
fix the confusing definition of F-based RPs

### DIFF
--- a/R/future.r
+++ b/R/future.r
@@ -2030,7 +2030,7 @@ get.stat <- function(fout,eyear=0,tmp.year=NULL, use_new_output=FALSE){
 
     #    Faa <- as.data.frame(t(fout$multi * fout$input$res0$Fc.at.age))
     # Faa <- as.data.frame(t(fout$multi * fout$currentF))
-    Faa <- as.data.frame(t(fout$multi * fout$futureF))    
+    if("finalmeanF" %in% names(fout)) Faa <- as.data.frame(t(fout$finalmeanF)) else Faa <- as.data.frame(t(fout$multi * fout$futureF))
     colnames(Faa) <- paste("F",dimnames(fout$naa)[[1]],sep="")
     res.stat1 <- cbind(a,Faa) # ここまで、get.stat
 

--- a/R/future_tmb.r
+++ b/R/future_tmb.r
@@ -1028,7 +1028,6 @@ get_summary_stat <- function(all.stat){
 #' @export
 #' 
 
-
 format_to_old_future <- function(fout){
     fout_old <- fout[c("naa","faa","multi","input","waa")]
 #    fout_old$waa       <- fout$input$tmb_data$waa_mat
@@ -1039,7 +1038,8 @@ format_to_old_future <- function(fout){
     fout_old$vbiom     <- apply(fout$naa * fout_old$waa, c(2,3),sum, na.rm=T)
     fout_old$vwcaa     <- apply(fout$wcaa,c(2,3),sum, na.rm=T)
     fout_old$currentF  <- fout$faa[,fout$input$tmb_data$start_ABC_year-1,1]
-    fout_old$futureF   <- fout$faa[,fout$input$tmb_data$start_ABC_year,1]    
+    fout_old$futureF   <- fout$faa[,fout$input$tmb_data$start_ABC_year,1]
+    fout_old$finalmeanF<- fout$faa[,dim(fout$faa)[[2]],] %>% apply(1,mean) # newly define
     fout_old$caa       <- fout$wcaa/fout_old$waa
     fout_old$multi     <- fout$multi
     fout_old$recruit   <- fout$SR_mat[,,"recruit"]


### PR DESCRIPTION
#231 にも関連します．
管理基準値を計算したあとのFのベクトルを取り出すさい，以前は暗黙的にfutureF(ABC計算年以降のＦ) x 乗数としていましたが，この変更で，最終年のＦのシミュレーション間の平均値=finalmeanFとし，この値が返されている場合にはこれをF管理基準値として利用する，というようにしました．