### PR TITLE
:construction_worker: Measure coverage

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@ vignettes/future-old.Rmd
 
 
 ^\.travis\.yml$
+^codecov\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ sudo: false
 warnings_are_errors: false
 r_check_args: "--no-manual --as--cran"
 cache: packages
+
+r_packages:
+  - covr
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,4 @@ language: R
 sudo: false
 warnings_are_errors: false
 r_check_args: "--no-manual --as--cran"
-cache: packages;
-before_deploy:
-  - git config --local user.name "smxshxishxad"
-  - git config --local user.email "akira.hayashi.1987@gmail.com"
-  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
-  - git tag $TRAVIS_TAG
-deploy:
-  provider: releases
-  api_key: "GITHUB OAUTH TOKEN"
-  file: "FILE TO UPLOAD"
-  skip_cleanup: true
-  on:
-    tags: true
+cache: packages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,5 +29,6 @@ Suggests:
     rmarkdown,
     testthat,
     foreach,
-    doParallel
+    doParallel,
+    covr
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # frasyr
   [![Travis build status](https://travis-ci.com/ichimomo/frasyr.svg?branch=master)](https://travis-ci.com/ichimomo/frasyr)
+  [![Codecov test coverage](https://codecov.io/gh/ichimomo/frasyr/branch/master/graph/badge.svg)](https://codecov.io/gh/ichimomo/frasyr?branch=master)
 - Fisheries Research Agency (FRA) provides the method for calculating sustainable yield (SY) with R
 - 水研機構で開発した，MSYを基礎とした目標管理基準値を計算するためのRのパッケージです．開発途中のものであること，ご承知おきください．
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
# やったこと
pushのたびにTravisがカバレッジ（コードのテストカバー率）を測定するようにしました。https://github.com/ichimomo/frasyr/pull/277/commits/c08ecf5c878da0011dc161c3a5aaf5cfe1105a88
今後、新たに関数を追加したとき、対応するテストがないと警告が出るようになります。
テストが不要なもの（プロット関数など）は無視するようにもできます。


## 追加でやったこと
 不要な設定を削除 https://github.com/ichimomo/frasyr/pull/277/commits/dc7e1059759361730b8685721258111cdd367f34
