### PR TITLE
put back argument sigma.const

### DIFF
--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -525,6 +525,7 @@ vpa <- function(
   b.const = 1:length(abund),   # bパラメータの制約（0は推定しないで1にfix）
   q.fix = NULL,
   b.fix = NULL,
+  sigma.const = 1:length(abund),
   fixed.index.var = NULL,
   max.iter = 100,    # q,b,sigma計算の際の最大繰り返し数
   optimizer = "nlm",
@@ -554,7 +555,7 @@ vpa <- function(
   #   compile(cpp_name)
   #   dyn.load(dynlib(tmb.file))
   # }
-
+  
   # inputデータをリスト化
 
   argname <- ls()  # 関数が呼び出されたばかりのときのls()は引数のみが入っている


### PR DESCRIPTION
vpa関数の引数に，形だけ，sigma.constを戻しました．
sigma.const=1:length(abund)，
sigma.constraint=1:length(abund)
で意味は同じで，旧sigma.constが使われていたところは
fixed.index.varが設定されてはじめて使われるものなので，
実際のコード内ではsigma.constraintで統一されたままで問題ないのでここ以外はいじっていません