### PR TITLE
:sparkles: Add functions for handling tables

### DIFF
--- a/R/tables.R
+++ b/R/tables.R
@@ -1,12 +1,13 @@
 make_stock_table <- function(result_vpa, result_msy,
-                             yr_pre_abc, unit = "百トン") {
+                             yr_future_start, unit = "百トン") {
   return_ <- function() {
     rbind(recent_five_years_(),
           future_start_year_())
   }
 
-  yr_newest_recent    <- yr_pre_abc[length(yr_pre_abc)]
-  yr_oldest_recent    <- yr_pre_abc[1]
+  n_years_to_display  <- 6
+  yr_newest_recent    <- yr_future_start - 1
+  yr_oldest_recent    <- yr_future_start - (n_years_to_display - 1)
   recent_five_years_ <- function() {
     data.frame(Year     = yr_oldest_recent:yr_newest_recent,
                Biomass  = get_x_from_vpa_("biomass"),
@@ -17,7 +18,7 @@ make_stock_table <- function(result_vpa, result_msy,
   }
   future_start_year_ <- function() {
     # not implemented
-    data.frame(Year = yr_newest_recent + 1,
+    data.frame(Year = yr_future_start,
                Biomass = NA,
                SSB     = NA,
                Catch   = NA,

--- a/R/tables.R
+++ b/R/tables.R
@@ -277,3 +277,50 @@ summary_of_summary <- function(tbl_msy, tbl1, tbl2, tbl4) {
     make_row(key = name3, value = ""),
     characterize_valuecol_(tbl4))
 }
+
+
+#' Export tables to csv
+#'
+#' @param to Name of file
+#' @param ... Table objects
+#'
+#' \dontrun{
+#' export_tables(to = "hoge.csv",
+#'               table1, table2, table3)
+#' }
+export_tables <- function(to, ...) {
+
+  write_tables_to_csv_ <- function() {
+    initialize_csv_()
+    list2csv_()
+  }
+
+  initialize_csv_ <- function() {
+    readr::write_excel_csv(data.frame(this_is_dummy = ""),
+                           path      = to,
+                           append    = FALSE,
+                           col_names = FALSE)
+  }
+
+  list2csv_ <- function() {
+
+    add_blank_line_ <- function(df) {
+      blank <- ""
+      suppressWarnings(
+        rbind(dplyr::mutate_all(df, as.character()),
+              blank,
+              stringsAsFactors = FALSE)
+      )
+    }
+
+    purrr::map(purrr::map(list(...), add_blank_line_),
+               readr::write_excel_csv,
+               path      = to,
+               append    = TRUE,
+               col_names = TRUE,
+               delim     = ",") %>%
+      invisible()
+  }
+
+  write_tables_to_csv_()
+}

--- a/R/tables.R
+++ b/R/tables.R
@@ -255,3 +255,25 @@ make_abctable <- function(kobe_table, result_future, beta, year, faa_pre, faa_af
   }
   return_()
 }
+
+summary_of_summary <- function(tbl_msy, tbl1, tbl2, tbl4) {
+  characterize_valuecol_ <- function(tb) {
+    tb$値 <- as.character(tb$値)
+    force(tb)
+  }
+  extract_yr_from_tbl_ <- function() {
+    force(stringr::str_extract(tbl1$項目[1], "[0-9]{4}"))
+  }
+  name1 <- "管理基準値とMSYに関係する値"
+  name2 <- paste0(extract_yr_from_tbl_(), "漁期の親魚量と漁獲圧")
+  name3 <- "MSYを実現する水準に対する比率"
+
+  dplyr::bind_rows(
+    make_row(key = name1, value = ""),
+    characterize_valuecol_(tbl_msy),
+    characterize_valuecol_(tbl1),
+    make_row(key = name2, value = ""),
+    characterize_valuecol_(tbl2),
+    make_row(key = name3, value = ""),
+    characterize_valuecol_(tbl4))
+}

--- a/tests/testthat/test-tables.R
+++ b/tests/testthat/test-tables.R
@@ -7,7 +7,7 @@ assertthat::assert_that(
   head(colnames(result_vpa$ssb), 1) == "1982",
   tail(colnames(result_vpa$ssb), 1) == "2011"
 )
-recent_years <- 2008:2011
+yrs_pre_abc <- 2008:2011
 
 test_colname <- function(tbl) {
   expect_equal(colnames(tbl), c("項目", "値", "備考"))
@@ -18,17 +18,17 @@ expect_df <- function(tbl) {
 
 test_that("make_stock_table() works", {
   tbl <- make_stock_table(result_vpa, result_msy,
-                          yr_pre_abc = recent_years)
+                          yr_future_start = 2012)
   expect_df(tbl)
   expect_equal(colnames(tbl),
                c("Year", "Biomass", "SSB", "Catch", "F.Fmsy", "HarvestRate"))
   expect_equal(tbl$Year,
-               c(recent_years, 2012))
+               2007:2012) # Six years including yr_future_start
 })
 
 test_that("table1() works", {
   tbl <- table1(result_vpa = result_vpa,
-                yrs_preabc = recent_years)
+                yrs_preabc = yrs_pre_abc)
   expect_df(tbl)
   test_colname(tbl)
 
@@ -37,7 +37,7 @@ test_that("table1() works", {
 
 test_that("table2() works", {
   tbl <- table2(result_vpa = result_vpa,
-                yrs_preabc = recent_years)
+                yrs_preabc = yrs_pre_abc)
   expect_df(tbl)
   test_colname(tbl)
 
@@ -64,7 +64,7 @@ test_that("make_msytable() works", {
 
 test_that("table4() works", {
   tbl <- table4(result_vpa = result_vpa,
-                yrs_preabc = recent_years,
+                yrs_preabc = yrs_pre_abc,
                 fmsy       = c(0.123, 0.234, 0.345),
                 sbtarget   = 12345)
   expect_df(tbl)

--- a/tests/testthat/test-tables.R
+++ b/tests/testthat/test-tables.R
@@ -72,6 +72,20 @@ test_that("table4() works", {
   expect_equal(tbl$項目, c("SB2011/ SBtarget(SBmsy)", "F2011/ Fmsy"))
 })
 
+test_that("summary_of_summary() works", {
+  tbl <- summary_of_summary(tbl_msy = make_msytable(result_msy),
+                            tbl1    = table1(result_vpa = result_vpa,
+                                             yrs_preabc = yrs_pre_abc),
+                            tbl2    = table2(result_vpa = result_vpa,
+                                             yrs_preabc = yrs_pre_abc),
+                            tbl4    = table4(result_vpa = result_vpa,
+                                             yrs_preabc = yrs_pre_abc,
+                                             fmsy = c(0.123, 0.234, 0.345),
+                                             sbtarget = 12345))
+  expect_df(tbl)
+  test_colname(tbl)
+})
+
 context("Inner functions for making tables")
 
 test_that("make_row() works", {


### PR DESCRIPTION
# やったこと

- 「要約表の要約表」なるものをつくるための`summary_of_summary()` の追加 https://github.com/ichimomo/frasyr/commit/24361b897433cd25bfa1839e8821869f9dbc0cd3
- 表をcsvに書き出す `export_csv()` の追加 57460a5
