### PR TITLE
:bug: Make make_summary_table() return data.frame not matrix

### DIFF
--- a/R/utilities.r
+++ b/R/utilities.r
@@ -557,7 +557,8 @@ make_summary_table <- function(mat_data,side=1,probs=c(0.1,0.5,0.8)){
   res_mat <- cbind(apply(mat_data,side,mean),
                    t(apply(mat_data,side,quantile,probs=probs)))
   colnames(res_mat)[1] <- "average"
-  res_mat
+
+  as.data.frame(res_mat)
 }
 
 


### PR DESCRIPTION
# やったこと
`make_summary_table()` の修正
昨日の変更で、 df が期待されるところを matrix 出すようにしてしまったので、戻しました。
`as_tibble()` だと`rowname`が消えてしまうので、`as.data.frame()`を使っています。
すみません。

Fix #368