### PR TITLE
fix bug on alpha for Pope=TRUE

### DIFF
--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -665,7 +665,7 @@ vpa <- function(
   if (!tune & sel.update) print("sel.update = TRUE but tune=FALSE. So, the results are unreliable.")
   if (tune & is.null(sel.f) & (!sel.update & term.F=="max")) print("sel.f=NULL although tune=TRUE & sel.update=FALSE & term.F=max. The results are unreliable.")
   if (tune) if(length(abund)!=nrow(index)) print("Check!: The number of abundance definition is different from the number of indices.")
-  if (Pope & alpha!=1) print("Warning! The estimated F for the older ages may not be precise if C<<N is not satisfied for the older ages.")
+  if (Pope & alpha!=1) print("Warning! The estimated F for the older ages may not be accurate if C<<N is not satisfied for the older ages.")
 #  ssb.def
 
   if (ssb.def=="i") ssb.coef <- 0

--- a/tests/testthat/test-data.handler.R
+++ b/tests/testthat/test-data.handler.R
@@ -214,6 +214,15 @@ test_that("future_vpa function (with dummy vpa data) (level 2-3?)",{
   expect_equal(as.numeric(round(res_vpa_estb_tune2m_b$sigma,2)),c(0.18,0.16,0.11,0.13,0.17,0.28))
   expect_equal(as.numeric(round(rowMeans(res_vpa_estb_tune2m_b$saa),2)),c(0.46,0.65,1.00,1.00))
   
+  #選択率更新法：選択率の計算方法は，最高齢を１とする．最尤法．b推定する,alphaを与える
+  res_vpa_estb_tune2m_b_alpha <- vpa(vpadat_estb, tf.year=1997:1999, last.catch.zero = FALSE, 
+                               Pope = TRUE, p.init = 0.5, tune=TRUE, term.F="max",sel.def="max",sel.update=TRUE, est.method="ml", b.est=TRUE,abund=c("N","N","N","N","N","N"),fc.year=1998:2000,min.age=c(0,0,0,0,0,0),max.age=c(3,3,0,0,3,3),alpha=0.3)
+  expect_equal(as.numeric(round(rowMeans(res_vpa_estb_tune2m_b_alpha $naa),2)),c(935.10,501.99,257.51,291.44))
+  expect_equal(as.numeric(round(res_vpa_estb_tune2m_b_alpha $b,2)),c(1.54,0.77,0.82,0.54,1.02,1.84))
+  expect_equal(as.numeric(round(res_vpa_estb_tune2m_b_alpha $sigma,2)),c(0.17,0.17,0.10,0.15,0.16,0.24))
+  expect_equal(as.numeric(round(rowMeans(res_vpa_estb_tune2m_b_alpha $saa),2)),c(0.72,0.86,0.98,0.30))
+  expect_equal(as.numeric(res_vpa_estb_tune2m_b_alpha $faa[3,]*0.3),as.numeric(res_vpa_estb_tune2m_b_alpha $faa[4,]))
+  
   #選択率更新法：選択率の計算方法は，最高齢を１とする．最尤法．b推定する.指標の2番目と3番目のシグマは同じ
   res_vpa_estb_tune2m_b_sigma <- vpa(vpadat_estb, tf.year=1997:1999, last.catch.zero = FALSE, 
                                Pope = TRUE, p.init = 0.5, tune=TRUE, term.F="max",sel.def="max",sel.update=TRUE, est.method="ml", b.est=TRUE,abund=c("N","N","N","N","N","N"),fc.year=1998:2000,min.age=c(0,0,0,0,0,0),max.age=c(3,3,0,0,3,3),sigma.constraint=c(1,2,2,3,4,5))
@@ -327,10 +336,10 @@ test_that("future_vpa function (with dummy vpa data) (level 2-3?)",{
   # 　全F推定法．最尤法．b推定あり，alpha=0.8(最高齢と最高齢―1のFの比：Fa=alpha*Fa-1)
   res_vpa_estb_tune4m_b_alpha <- vpa(vpadat_estb, last.catch.zero = FALSE, min.age=c(0,0,0,0,0,0),max.age=c(3,3,0,0,3,3),
                                         Pope = TRUE,  tune=TRUE, term.F="all",est.method="ml" ,b.est=TRUE, p.init=c(0.2,0.3,0.6,0.6),abund=c("N","N","N","N","N","N"),alpha=0.8,fc.year=1998:2000)
-  expect_equal(as.numeric(round(rowMeans(res_vpa_estb_tune4m_b_alpha$naa),2)),c(711.17,344.77,147.22,65.05))
-  expect_equal(as.numeric(round(res_vpa_estb_tune4m_b_alpha$b,2)),c(1.00,0.52,0.70,0.48,0.65,1.14))
-  expect_equal(as.numeric(round(res_vpa_estb_tune4m_b_alpha$sigma,2)),c(0.18,0.16,0.10,0.14,0.17,0.28))
-  expect_equal(as.numeric(round(rowMeans(res_vpa_estb_tune4m_b_alpha$saa),2)),c(0.47,0.67,1.00,0.80))
+  expect_equal(as.numeric(round(rowMeans(res_vpa_estb_tune4m_b_alpha$naa),2)),c(712.60,346.43,149.16,72.54))
+  expect_equal(as.numeric(round(res_vpa_estb_tune4m_b_alpha$b,2)),c(0.98,0.51,0.69,0.48,0.63,1.11))
+  expect_equal(as.numeric(round(res_vpa_estb_tune4m_b_alpha$sigma,2)),c(0.18,0.16,0.10,0.13,0.17,0.28))
+  expect_equal(as.numeric(round(rowMeans(res_vpa_estb_tune4m_b_alpha$saa),2)),c(0.48,0.68,1.00,0.80))
 
   
   #1-4: Ridge VPA ----
@@ -529,11 +538,11 @@ test_that("future_vpa function (with dummy vpa data) (level 2-3?)",{
   # 　全F推定法．最尤法．b推定あり，alpha=0.8(最高齢と最高齢―1のFの比：Fa=alpha*Fa-1)
   res_vpa_pgc0_estb_tune4m_b_alpha <- vpa(vpadat_pgc0_estb, last.catch.zero = FALSE, min.age=c(0,0,0,0,0,0),max.age=c(3,3,0,0,3,3),
                                      Pope = TRUE,  tune=TRUE, term.F="all",est.method="ml" ,b.est=TRUE, p.init=c(0.2,0.3,0.6,0.6),abund=c("N","N","N","N","N","N"),alpha=0.8,fc.year=1998:2000)
-  expect_equal(as.numeric(round(rowMeans(res_vpa_pgc0_estb_tune4m_b_alpha$naa),2)),c(632.71,296.55,150.07,NA))
-  expect_equal(as.numeric(round(res_vpa_pgc0_estb_tune4m_b_alpha$b,2)),c(0.56,0.27,0.46,0.31,0.36,0.62))
-  expect_equal(as.numeric(round(res_vpa_pgc0_estb_tune4m_b_alpha$sigma,2)),c(0.20,0.18,0.11,0.14,0.18,0.31))
-  expect_equal(as.numeric(round(rowMeans(res_vpa_pgc0_estb_tune4m_b_alpha$saa),2)),c(0.55,0.89,0.88,NA))
-
+  expect_equal(as.numeric(round(rowMeans(res_vpa_pgc0_estb_tune4m_b_alpha$naa),2)),c(632.24,297.58,161.80,NA))
+  expect_equal(as.numeric(round(res_vpa_pgc0_estb_tune4m_b_alpha$b,2)),c(0.56,0.27,0.46,0.31,0.35,0.61))
+  expect_equal(as.numeric(round(res_vpa_pgc0_estb_tune4m_b_alpha$sigma,2)),c(0.19,0.18,0.11,0.14,0.18,0.31))
+  expect_equal(as.numeric(round(rowMeans(res_vpa_pgc0_estb_tune4m_b_alpha$saa),2)),c(0.54,0.89,0.87,NA))
+  
   #2-4: Ridge VPA ----
   # set lambda + 全F推定法．最尤法．b推定あり
   res_vpa_pgc0_estb_tune5m_b <- vpa(vpadat_pgc0_estb, last.catch.zero = FALSE,  min.age=c(0,0,0,0,0,0),max.age=c(3,3,0,0,3,3),


### PR DESCRIPTION
1．Popeの近似式を用いた場合のalphaの式を修正しました．修正した式はいくつかの近似を使っていて，一つは，高齢のMは一定であるということ，もう一つは漁獲係数Fが漁獲率（C/N)に等しいという近似です．ので，高齢のMが一定でなかったり，C<<Nでない場合には注意をする必要があるので，Popeでalphaを1以外に設定した場合は近似であることのWarningが出るように設定しました（また，厳密に言うと，alpha=1の通常の場合でも，高齢のMは一定であるという近似を置いています）．これらの厳密な解を得るとなると，解析的には解けず，数値計算が必要で複雑になるので，ここでは近似を用いることにしています．

2．選択率更新法でalphaを1以下に設定した場合のテストを書いていなかったので，加えました．