### PR TITLE
レトロスペクティブ解析関数の修正 #404

### DIFF
--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -348,7 +348,9 @@ do_retrospective_vpa <- function(res, n_retro = 5, b_reest = FALSE,
   rho_data <- tibble(index = names(res_retro$mohn), value = res_retro$mohn) %>%
     left_join(tibble(index = c("N", "B", "SSB", "R", "F"),
                      stat = c("fish_number", "biomass" ,"SSB" ,"Recruitment" ,"fishing_mortality"))) %>%
-    mutate(y=0, x=as.numeric(min(colnames(res_retro[[1]][[1]]$naa))))
+    #mutate(y=0, x=as.numeric(min(colnames(res_retro[[1]][[1]]$naa))))
+    mutate(y = 0,
+           x = if(is.null(plot_year))as.numeric(min(colnames(res_retro[[1]][[1]]$naa))) else plot_year[1])
 
   g1 <- plot_vpa(dat_graph,
                  what.plot = factor(what_plot, levels = as.character(what_plot)),

--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -341,7 +341,7 @@ do_retrospective_vpa <- function(res, n_retro = 5, b_reest = FALSE,
   res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest)
   dat_graph <- list()
   for(i in 1:n_retro) dat_graph[[i]] <- res_retro$Res[[i]]
-  dat_graph <- c(list(res), dat_graph) # Base case(全データで解析)の追加（浜辺07/08）
+  dat_graph <- c(list(res), dat_graph)  # Base case(全データで解析)の追加（浜辺07/08）
   names(dat_graph) <- rev(colnames(res$ssb))[1:(n_retro+1)]  # 図にinputされる結果に名前をつける
 
   # 図にMohn's rhoの重ね書き用rho data from 市野川さん

--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -341,7 +341,8 @@ do_retrospective_vpa <- function(res, n_retro = 5, b_reest = FALSE,
   res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest)
   dat_graph <- list()
   for(i in 1:n_retro) dat_graph[[i]] <- res_retro$Res[[i]]
-  names(dat_graph) <- rev(colnames(res$ssb))[1:n_retro]  # 図にinputされる結果に名前をつける
+  dat_graph <- c(list(res), dat_graph) # Base case(全データで解析)の追加（浜辺07/08）
+  names(dat_graph) <- rev(colnames(res$ssb))[1:(n_retro+1)]  # 図にinputされる結果に名前をつける
 
   # 図にMohn's rhoの重ね書き用rho data from 市野川さん
   rho_data <- tibble(index = names(res_retro$mohn), value = res_retro$mohn) %>%

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -1549,7 +1549,7 @@ retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE){
      res.c$input$b.est <- FALSE
    }
 
-   if (res$input$last.catch.zero) res.c$input$last.catch.zero <- FALSE
+   #if (res$input$last.catch.zero) res.c$input$last.catch.zero <- FALSE
 
    for (i in 1:n){
      nc <- ncol(res.c$input$dat$caa)
@@ -1573,16 +1573,19 @@ retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE){
 
      if (isTRUE(init.est)) res.c$input$p.init <- res.c$term.f
 
+     # last.catch.zero = TRUE用に修正
+     if (res.c$input$last.catch.zero) {res.c$input$dat$caa[,nc-1] <- 0; Y <- nc-2} else Y <- nc-1
+
      res1 <- safe_call(vpa,res.c$input, force=TRUE) # do.callからsafe_callに変更(浜辺'20/06/30)
 
      Res[[i]] <- res1
 
-     if ((max(abs(res1$gradient)) < 10^(-3) & !isTRUE(res1$input$TMB)) | (max(abs(res1$gradient)) > 0 & max(abs(res1$gradient)) < 10^(-3) & isTRUE(res1$input$TMB)) | (is.na(max(abs(res1$gradient))) & res1$input$optimizer=="nlminb")){
-        obj.n <- c(obj.n, (sum(res1$naa[,nc-1])-sum(res$naa[,nc-1]))/sum(res$naa[,nc-1]))
-        obj.b <- c(obj.b, (sum(res1$baa[,nc-1])-sum(res$baa[,nc-1]))/sum(res$baa[,nc-1]))
-        obj.s <- c(obj.s, (sum(res1$ssb[,nc-1])-sum(res$ssb[,nc-1]))/sum(res$ssb[,nc-1]))
-        obj.r <- c(obj.r, (res1$naa[1,nc-1]-res$naa[1,nc-1])/res$naa[1,nc-1])
-        obj.f <- c(obj.f, (sum(res1$faa[,nc-1])-sum(res$faa[,nc-1]))/sum(res$faa[,nc-1]))
+     if ((max(abs(res1$gradient)) < 10^(-3) & !isTRUE(res1$input$ADMB)) | (max(abs(res1$gradient)) > 0 & max(abs(res1$gradient)) < 10^(-3) & isTRUE(res1$input$ADMB)) | (is.na(max(abs(res1$gradient))) & res1$input$optimizer=="nlminb")){
+       obj.n <- c(obj.n, (sum(res1$naa[,Y])-sum(res$naa[,Y]))/sum(res$naa[,Y]))
+       obj.b <- c(obj.b, (sum(res1$baa[,Y])-sum(res$baa[,Y]))/sum(res$baa[,Y]))
+       obj.s <- c(obj.s, (sum(res1$ssb[,Y])-sum(res$ssb[,Y]))/sum(res$ssb[,Y]))
+       obj.r <- c(obj.r, (res1$naa[1,Y]-res$naa[1,Y])/res$naa[1,Y])
+       obj.f <- c(obj.f, (sum(res1$faa[,Y])-sum(res$faa[,Y]))/sum(res$faa[,Y]))
      } else {
        obj.n <- c(obj.n, NA)
        obj.b <- c(obj.b, NA)
@@ -1600,6 +1603,10 @@ retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE){
 }
 
 #最新年の漁獲量が0の場合 (last.zero.catch=0)、最新年のFが0となり、加入量も推定できないため、もう1年前の推定値でMohn's rhoを計算するための関数
+## ------------------------------------------------------  ##
+# retro.est中にlast.zero.catch=0の場合のif文加えた
+# retro.estが問題なければ以下関数は捨てても大丈夫（浜辺07/07）
+## ------------------------------------------------------  ##
 retro.est2 <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE){
    res.c <- res
    res.c$input$plot <- FALSE


### PR DESCRIPTION
レトロスペクティブ解析関数について複数修正を加えた

- do_retrospective_vpa関数の作図結果と凡例がずれる #404 
- do_retrospective_vpa関数でplot_yearを指定するとMohn's rhoが隠れてしまう
- retro.est2にあったvpa(,last.catch.zero=TRUE,)用コードの機能移行(retro.estに移行)
