### PR TITLE
last.catch.zero時のレトロ作図の修正

### DIFF
--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -341,8 +341,13 @@ do_retrospective_vpa <- function(res, n_retro = 5, b_reest = FALSE,
   res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest)
   dat_graph <- list()
   for(i in 1:n_retro) dat_graph[[i]] <- res_retro$Res[[i]]
-  dat_graph <- c(list(res), dat_graph) # Base case(全データで解析)の追加（浜辺07/08）
-  names(dat_graph) <- rev(colnames(res$ssb))[1:(n_retro+1)]  # 図にinputされる結果に名前をつける
+
+  if(res$input$last.catch.zero){ # last.catch.zero=Tの場合、最終年のプロットはしない（Mohn's rhoとずれるから）（浜辺07/08）
+    names(dat_graph) <- rev(colnames(res$ssb))[2:(n_retro+1)]
+  } else {
+    dat_graph <- c(list(res), dat_graph) # Base case(全データで解析)の追加（浜辺07/08）
+    names(dat_graph) <- rev(colnames(res$ssb))[1:(n_retro+1)]  # 図にinputされる結果に名前をつける
+  }
 
   # 図にMohn's rhoの重ね書き用rho data from 市野川さん
   rho_data <- tibble(index = names(res_retro$mohn), value = res_retro$mohn) %>%


### PR DESCRIPTION
last.catch.zero時に最後の年まで作図するとMohn's rhoの結果と作図結果が異なってしまう #410 

以下のようにif文分岐に修正
https://github.com/KoheiHAMABE/frasyr/blob/5b584a317d4ae723441bd8506e02d6decaf069a7/R/diagnostics_vpa.R#L345-L350

明朝、travisが〇だったらマージ予定