### PR TITLE
Fix retro

### DIFF
--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -310,7 +310,7 @@ do_sensitivity_vpa <- function(res, what_replace, value, what_plot = NULL, ncol 
 #' @param ncol 作図の列数。標準で5列なので、\code{what_plot}の数が5以下の場合は適宜変えた方がよい。
 #' @param remove_maxAgeF Mohn's rhoを計算する際に最高齢のFを除くか（alphaを仮定して計算していることが多いから）
 #' @param ssb_forecast Mohn's rhoを計算する際にSSBは1年後を計算するか(last.catch.zero=TRUEのときのみ有効)
-#'
+#' @param res_step1 2段階法のレトロ解析をやる場合の1段階目の\code{vpa}オブジェクト
 #' @return 返ってくる値:
 #'     \code{result} 感度分析の結果が\code{list}型式で得られる。
 #'     \code{mohn_rho}
@@ -335,13 +335,20 @@ do_retrospective_vpa <- function(res, n_retro = 5, b_reest = FALSE,
                                                "fish_number", "fishing_mortality"),
                                  plot_year = NULL,
                                  ncol = 3, 
-                                 remove_maxAge=FALSE,ssb_forecast=FALSE){
+                                 remove_maxAgeF=FALSE,ssb_forecast=FALSE,res_step1=NULL){
 
   if(b_reest == TRUE && res$input$b.est == FALSE)message(paste('b was not estimated in your vpa model'))
   # vpa内でbの推定をしていないにもかかわらず、b_reestがtrueで入力された場合
   # 推定結果(bを推定している)は得られるが、メッセージを出す
 
-  res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest, remove.maxAge=remove_maxAge, ssb.forecast=ssb_forecast)
+  if (!is.null(res_step1)) { #二段階法の場合のレトロ    i
+    retro_step_one <- retro.est(res_step1, n = n_retro)
+    yy <- ifelse(res$input$last.catch.zero,2,1)
+    sel_mat <- sapply(1:n_retro, function(i) rev(retro_step_one$Res[[i]]$saa)[,yy])
+    res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest, remove.maxAgeF=remove_maxAgeF, ssb.forecast=ssb_forecast,sel.mat=sel_mat)
+    } else {
+    res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest, remove.maxAgeF=remove_maxAgeF, ssb.forecast=ssb_forecast)
+  }
   dat_graph <- list()
   for(i in 1:n_retro) dat_graph[[i]] <- res_retro$Res[[i]]
 

--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -308,6 +308,8 @@ do_sensitivity_vpa <- function(res, what_replace, value, what_plot = NULL, ncol 
 #' @param b_reest bをレトロスペクティブ解析中で再推定するか
 #' @param what_plot 作図したい項目を選べる。\code{NULL}の場合、全て（SSB, biomass, U, catch, Recruitment, fish_number, fishing_mortality, weight, maturity, catch_number）をプロットする。
 #' @param ncol 作図の列数。標準で5列なので、\code{what_plot}の数が5以下の場合は適宜変えた方がよい。
+#' @param remove_maxAgeF Mohn's rhoを計算する際に最高齢のFを除くか（alphaを仮定して計算していることが多いから）
+#' @param ssb_forecast Mohn's rhoを計算する際にSSBは1年後を計算するか(last.catch.zero=TRUEのときのみ有効)
 #'
 #' @return 返ってくる値:
 #'     \code{result} 感度分析の結果が\code{list}型式で得られる。
@@ -332,13 +334,14 @@ do_retrospective_vpa <- function(res, n_retro = 5, b_reest = FALSE,
                                  what_plot = c("SSB", "biomass", "Recruitment",
                                                "fish_number", "fishing_mortality"),
                                  plot_year = NULL,
-                                 ncol = 3){
+                                 ncol = 3, 
+                                 remove_maxAge=FALSE,ssb_forecast=FALSE){
 
   if(b_reest == TRUE && res$input$b.est == FALSE)message(paste('b was not estimated in your vpa model'))
   # vpa内でbの推定をしていないにもかかわらず、b_reestがtrueで入力された場合
   # 推定結果(bを推定している)は得られるが、メッセージを出す
 
-  res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest)
+  res_retro <- retro.est(res, n = n_retro, b.fix = !b_reest, remove.maxAge=remove_maxAge, ssb.forecast=ssb_forecast)
   dat_graph <- list()
   for(i in 1:n_retro) dat_graph[[i]] <- res_retro$Res[[i]]
 

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -1543,7 +1543,7 @@ cv.est <- function(res,n=5){
 #'
 
 retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE,
-                      remove.maxAgeF=FALSE,ssb.forecast=FALSE){
+                      remove.maxAgeF=FALSE,ssb.forecast=FALSE,sel.mat=NULL){
    res.c <- res
    res.c$input$plot <- FALSE
    Res <- list()
@@ -1581,6 +1581,13 @@ retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE,
      res.c$input$fc.year <- res.c$input$fc.year-1
      if (!is.null(res.c$input$tf.mat)) res.c$input$tf.mat <- res.c$input$tf.mat[,-1]
 
+     if (!is.null(sel.mat)) {
+       if (any(dim(sel.mat) != c(nrow(res$saa),n))) {
+         stop("Dimension of 'sel.mat' is not appropriate")
+       } else {
+         res.c$input$sel.f <- sel.mat[,i] #2stepの方のときチューニングなしの時の選択率を行列で使う
+       }
+     }
      if (isTRUE(init.est)) res.c$input$p.init <- res.c$term.f
 
      # last.catch.zero = TRUE用に修正

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -1200,7 +1200,7 @@ vpa <- function(
       log_F=log(p.init)
     )
 
-    obj <- try(MakeADFun(data2, parameters, DLL=tmb.file))
+    obj <- try(TMB::MakeADFun(data2, parameters, DLL=tmb.file))
     if (class(obj) == "try-error") {
       stop("Please run use_rvpa_tmb() first!")
     }

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -1534,15 +1534,21 @@ cv.est <- function(res,n=5){
 #' レトロスペクティブ解析の実施
 #'
 #' @param res VPAの出力
+#' @param n 除く年数
+#' @param b.fix b推定してる場合にbを固定するかどうか
+#' @param remove.maxAgeF Mohn's rhoを計算する際に最高齢のFを除くか（alphaを仮定して計算していることが多いから）
+#' @param ssb.forecast Mohn's rhoを計算する際にSSBは1年後を計算するか(last.catch.zero=TRUEのときのみ有効)
 #' @encoding UTF-8
 #' @export
 #'
 
-retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE){
+retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE,
+                      remove.maxAgeF=FALSE,ssb.forecast=FALSE){
    res.c <- res
    res.c$input$plot <- FALSE
    Res <- list()
    obj.n <- obj.b <- obj.s <- obj.r <- obj.f <- NULL
+   A <- nrow(res$faa)
 
    if (isTRUE(b.fix)){
      res.c$input$b.fix <- res$b
@@ -1550,6 +1556,10 @@ retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE){
    }
 
    #if (res$input$last.catch.zero) res.c$input$last.catch.zero <- FALSE
+   if (ssb.forecast && !(res.c$input$last.catch.zero)) {
+     warning("'ssb.forecast' is usable only when 'last.catch.zero=TRUE' and so ignored")
+   }
+     
 
    for (i in 1:n){
      nc <- ncol(res.c$input$dat$caa)
@@ -1583,9 +1593,17 @@ retro.est <- function(res,n=5,stat="mean",init.est=FALSE, b.fix=TRUE){
      if ((max(abs(res1$gradient)) < 10^(-3) & !isTRUE(res1$input$ADMB)) | (max(abs(res1$gradient)) > 0 & max(abs(res1$gradient)) < 10^(-3) & isTRUE(res1$input$ADMB)) | (is.na(max(abs(res1$gradient))) & res1$input$optimizer=="nlminb")){
        obj.n <- c(obj.n, (sum(res1$naa[,Y])-sum(res$naa[,Y]))/sum(res$naa[,Y]))
        obj.b <- c(obj.b, (sum(res1$baa[,Y])-sum(res$baa[,Y]))/sum(res$baa[,Y]))
-       obj.s <- c(obj.s, (sum(res1$ssb[,Y])-sum(res$ssb[,Y]))/sum(res$ssb[,Y]))
+       if (ssb.forecast && res.c$input$last.catch.zero) {
+         obj.s <- c(obj.s, (sum(res1$ssb[,Y+1])-sum(res$ssb[,Y+1]))/sum(res$ssb[,Y+1]))
+       } else {
+         obj.s <- c(obj.s, (sum(res1$ssb[,Y])-sum(res$ssb[,Y]))/sum(res$ssb[,Y]))
+       }
        obj.r <- c(obj.r, (res1$naa[1,Y]-res$naa[1,Y])/res$naa[1,Y])
-       obj.f <- c(obj.f, (sum(res1$faa[,Y])-sum(res$faa[,Y]))/sum(res$faa[,Y]))
+       if (remove.maxAgeF) {
+         obj.f <- c(obj.f, (sum(res1$faa[-A,Y])-sum(res$faa[-A,Y]))/sum(res$faa[-A,Y]))
+         } else {
+           obj.f <- c(obj.f, (sum(res1$faa[,Y])-sum(res$faa[,Y]))/sum(res$faa[,Y]))
+         }
      } else {
        obj.n <- c(obj.n, NA)
        obj.b <- c(obj.b, NA)

--- a/man/do_retrospective_vpa.Rd
+++ b/man/do_retrospective_vpa.Rd
@@ -12,8 +12,9 @@ do_retrospective_vpa(
   what_plot = c("SSB", "biomass", "Recruitment", "fish_number", "fishing_mortality"),
   plot_year = NULL,
   ncol = 3,
-  remove_maxAge = FALSE,
-  ssb_forecast = FALSE
+  remove_maxAgeF = FALSE,
+  ssb_forecast = FALSE,
+  res_step1 = NULL
 )
 }
 \arguments{
@@ -27,9 +28,11 @@ do_retrospective_vpa(
 
 \item{ncol}{作図の列数。標準で5列なので、\code{what_plot}の数が5以下の場合は適宜変えた方がよい。}
 
+\item{remove_maxAgeF}{Mohn's rhoを計算する際に最高齢のFを除くか（alphaを仮定して計算していることが多いから）}
+
 \item{ssb_forecast}{Mohn's rhoを計算する際にSSBは1年後を計算するか(last.catch.zero=TRUEのときのみ有効)}
 
-\item{remove_maxAgeF}{Mohn's rhoを計算する際に最高齢のFを除くか（alphaを仮定して計算していることが多いから）}
+\item{res_step1}{2段階法のレトロ解析をやる場合の1段階目の\code{vpa}オブジェクト}
 }
 \value{
 返ってくる値:

--- a/man/do_retrospective_vpa.Rd
+++ b/man/do_retrospective_vpa.Rd
@@ -11,7 +11,9 @@ do_retrospective_vpa(
   b_reest = FALSE,
   what_plot = c("SSB", "biomass", "Recruitment", "fish_number", "fishing_mortality"),
   plot_year = NULL,
-  ncol = 3
+  ncol = 3,
+  remove_maxAge = FALSE,
+  ssb_forecast = FALSE
 )
 }
 \arguments{
@@ -24,6 +26,10 @@ do_retrospective_vpa(
 \item{what_plot}{作図したい項目を選べる。\code{NULL}の場合、全て（SSB, biomass, U, catch, Recruitment, fish_number, fishing_mortality, weight, maturity, catch_number）をプロットする。}
 
 \item{ncol}{作図の列数。標準で5列なので、\code{what_plot}の数が5以下の場合は適宜変えた方がよい。}
+
+\item{ssb_forecast}{Mohn's rhoを計算する際にSSBは1年後を計算するか(last.catch.zero=TRUEのときのみ有効)}
+
+\item{remove_maxAgeF}{Mohn's rhoを計算する際に最高齢のFを除くか（alphaを仮定して計算していることが多いから）}
 }
 \value{
 返ってくる値:

--- a/man/retro.est.Rd
+++ b/man/retro.est.Rd
@@ -12,7 +12,8 @@ retro.est(
   init.est = FALSE,
   b.fix = TRUE,
   remove.maxAgeF = FALSE,
-  ssb.forecast = FALSE
+  ssb.forecast = FALSE,
+  sel.mat = NULL
 )
 }
 \arguments{

--- a/man/retro.est.Rd
+++ b/man/retro.est.Rd
@@ -5,10 +5,26 @@
 \alias{retro.est}
 \title{レトロスペクティブ解析の実施}
 \usage{
-retro.est(res, n = 5, stat = "mean", init.est = FALSE, b.fix = TRUE)
+retro.est(
+  res,
+  n = 5,
+  stat = "mean",
+  init.est = FALSE,
+  b.fix = TRUE,
+  remove.maxAgeF = FALSE,
+  ssb.forecast = FALSE
+)
 }
 \arguments{
 \item{res}{VPAの出力}
+
+\item{n}{除く年数}
+
+\item{b.fix}{b推定してる場合にbを固定するかどうか}
+
+\item{remove.maxAgeF}{Mohn's rhoを計算する際に最高齢のFを除くか（alphaを仮定して計算していることが多いから）}
+
+\item{ssb.forecast}{Mohn's rhoを計算する際にSSBは1年後を計算するか(last.catch.zero=TRUEのときのみ有効)}
 }
 \description{
 レトロスペクティブ解析の実施


### PR DESCRIPTION
一度間違ってそのままpushしてしまったので、revertで取り消して再度プルリクします（初めてcherry-pick使いました…）。`retro.est`に関して、

- Mohnの計算から最高齢のFを除外する引数を追加 (`remove.maxAgeF`)

- Mohnの計算でSSBは一年先を計算する引数（太平洋マサバ用）(`ssb.forecast`)

- 2段階法用に選択率の行列を追加できるように(`sel.mat`)

すべてデフォルト設定では影響しないようになっています。
それに合わせて`do_retrospective_vpa`も引数を加えていて、特に`res_step1`の引数に1段階目の結果を入れれば2段階のレトロ解析ができるようになっています。
