### PR TITLE
:+1: Get latest year from vpa result object

### DIFF
--- a/R/tables.R
+++ b/R/tables.R
@@ -148,8 +148,7 @@ adhoc_table <- function(result_vpa, yrs_preabc, number, sbtarget = NULL, fmsy = 
                    f_latest_over_msy_())
            })
   }
-  oldest_recentyr <- yrs_preabc[1]
-  yr_latest       <- yrs_preabc[length(yrs_preabc)]
+  yr_latest <- tail(extract_year_from(result_vpa), 1)
   sb_latest_ <- function() {
     make_row(key     = paste0("SB", yr_latest),
              value   = colSums(extract_from_vpa_("ssb"), na.rm = TRUE),
@@ -173,13 +172,15 @@ adhoc_table <- function(result_vpa, yrs_preabc, number, sbtarget = NULL, fmsy = 
              remarks = paste0(yr_latest, "年漁期の%SPR"))
   }
   pspr_recent_ <- function() {
-    years <- paste0(oldest_recentyr, "--", yr_latest)
+    oldest_recentyr <- yrs_preabc[1]
+    latest_recentyr <- yrs_preabc[length(yrs_preabc)]
+    years <- paste0(oldest_recentyr, "--", latest_recentyr)
     pspr  <- calc_future_perSPR(
       fout        = list(waa       = data_future$data$waa_mat,
                          maa       = data_future$data$maa_mat,
                          M         = data_future$data$M_mat,
                          waa.catch = data_future$data$waa_catch_mat),
-      Fvector     = apply_year_colum(result_vpa$faa, yr_latest:oldest_recentyr),
+      Fvector     = apply_year_colum(result_vpa$faa, latest_recentyr:oldest_recentyr),
       target.year = yr_biopar
     )
     make_row(key     = paste0("%SPR", wrap_by_paren(years)),


### PR DESCRIPTION
# やったこと
FAA_preABC_year のベクトル末尾が最新年とならないケースに対応しました。

Related to https://github.com/ichimomo/frasyr_tool/issues/210

Resolve #420