### PR TITLE
マダラ太平洋系群に対応

### DIFF
--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -448,7 +448,7 @@ qbs.f2 <- function(p0,index, Abund, nindex, index.w, fixed.index.var=NULL){
 #' @param tf.mat terminal Fの平均をとる年の設定．NA行列に平均をとる箇所に1を入れる．
 #' @param eq.tf.mean terminal Fの平均値を過去のFの平均値と等しくする
 #' @param no.est  パラメータ推定しない．
-#' @param est.method 推定方法 （ls = 最小二乗法，ml = 最尤法）
+#' @param est.method 推定方法 （ls = 最小二乗法，ml = 最尤法,  ls_nolog =最小二乗法で実数)
 #' @param b.est bを推定するかどうか
 #' @param est.constraint  制約付き推定をするかどうか
 #' @param q.const  qパラメータの制約（0は推定しないで1にfix）
@@ -473,6 +473,7 @@ qbs.f2 <- function(p0,index, Abund, nindex, index.w, fixed.index.var=NULL){
 #' @param eta  Fのpenaltyを分けて与えるときにeta.ageで指定した年齢への相対的なpenalty (0~1)
 #' @param eta.age  Fのpenaltyを分けるときにetaを与える年齢(0 = 0歳（加入）,0:1 = 0~1歳)
 #' @param tmb.file  TMB=TRUEのとき使用するcppファイルの名前
+#' @param madara  マダラ太平洋系群で用いているチューニングのやり方
 #' @encoding UTF-8
 #'
 #' @export

--- a/tests/testthat/test-data.handler.R
+++ b/tests/testthat/test-data.handler.R
@@ -485,6 +485,32 @@ test_that("vpa function (with dummy data) (level 2-3?)",{
   abund_vpadat_rec2_N0sj<- abund.extractor(dat=vpadat_rec2,abund="N0sj", naa=naa_base2, faa=faa_base2, min.age=2, max.age=4)
   expect_equal(as.numeric(abund_vpadat_rec2_N0sj),true_abun_N0sj)
   
+  
+  #1-6: madara法によるtuning ----
+  
+  #  madara法．最小二乗法．
+  res_vpa_base0_madara1 <- vpa(vpadat_base0, tf.year=2015:2016, last.catch.zero = FALSE, 
+                              Pope = TRUE, p.init = 0.5, tune=TRUE, term.F="max",sel.def="max",sel.update=FALSE, est.method="ls", b.est=FALSE,abund=c("B","B"),madara=TRUE)
+							  
+  expect_equal(as.numeric(round(rowMeans(res_vpa_base0_madara1$naa),2)),true_number,tol=0.0001)
+  expect_equal(as.numeric(round(res_vpa_base0_madara1$sigma,2)),true_sd,tol=0.01)
+  expect_equal(as.numeric(round(rowMeans(res_vpa_base0_madara1$saa),2)),c(0.42,0.58,1.00,1.00))
+  
+  #  madara法．最尤法．
+  res_vpa_base0_madara2 <- vpa(vpadat_base0, tf.year=2015:2016, last.catch.zero = FALSE, 
+                               Pope = TRUE, p.init = 0.5, tune=TRUE, term.F="max",sel.def="max",sel.update=FALSE, est.method="ml", b.est=FALSE,abund=c("B","B"),madara=TRUE)
+  expect_equal(as.numeric(round(rowMeans(res_vpa_base0_madara2$naa),2)),true_number,tol=0.0001)
+  expect_equal(as.numeric(round(res_vpa_base0_madara2$sigma,2)),rep(true_sd,2), tol=0.01)
+  expect_equal(as.numeric(round(rowMeans(res_vpa_base0_madara2$saa),2)),c(0.42,0.58,1.00,1.00))
+  
+  #  madara法．最小二乗法実数．
+  res_vpa_base0_madara3 <- vpa(vpadat_base0, tf.year=2015:2016, last.catch.zero = FALSE, 
+                               Pope = TRUE, p.init = 0.5, tune=TRUE, term.F="max",sel.def="max",sel.update=FALSE, est.method="ls_nolog", b.est=FALSE,abund=c("B","B"),madara=TRUE)
+  
+  expect_equal(as.numeric(round(rowMeans(res_vpa_base0_madara3$naa),2)),true_number,tol=0.0001)
+  expect_equal(as.numeric(round(res_vpa_base0_madara3$sigma,2)),0.5,tol=0.01)
+  expect_equal(as.numeric(round(rowMeans(res_vpa_base0_madara3$saa),2)),c(0.42,0.58,1.00,1.00))
+  
   # Part2: dataset is "vpadat_pgc0" for b.est=F, and "vpadat_pgc0_estb" for b.est=T (plus group changes in some years)----
   #現状では，Pope=FALSE（Baranovの方程式）の場合には対応していないのでPope=FALSEのテストは省略
   


### PR DESCRIPTION
マダラ太平洋系群のVPAを実装できるように主に二つの点を改良しました．

1．新しいチューニングオプションの追加（madara=TRUE)
マダラは，選択率更新法に似たようなチューニングのやり方をしていますが，ちょっと違って，例えば，蘇ら（2015）日本水産学会誌81(3), 418-428にあるような方法でチューニングをしています．その方法を加えました．

2．マダラはチューニングの際に最小二乗法を行うときに，対数をとるのでなく実数でチューニングしています．
その場合のオプションest.method="ls_nolog"を加えました．
対数をとる場合はbは解析的に解けていたので推定出来ていましたが，実数の場合はbは解析的には解けません．
ので，この場合はbは推定させるのでなく外部から与える，あるいはb=1というオプションに対応できるようにしております．

両方のオプションがきちんと動いているか確認するためのテストコードも加えました．