### PR TITLE
fix do_retrospective

### DIFF
--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -366,10 +366,10 @@ do_retrospective_vpa <- function(res,
   dat_graph <- list()
   for(i in 1:n_retro) dat_graph[[i]] <- res_retro$Res[[i]]
 
+  dat_graph <- c(list(res), dat_graph) # Base case(全データで解析)の追加（浜辺07/08）
   if(res$input$last.catch.zero){ # last.catch.zero=Tの場合、最終年のプロットはしない（Mohn's rhoとずれるから）（浜辺07/08）
-    names(dat_graph) <- rev(colnames(res$ssb))[2:(n_retro+1)]
+    names(dat_graph) <- rev(colnames(res$ssb))[2:(n_retro+2)]
   } else {
-    dat_graph <- c(list(res), dat_graph) # Base case(全データで解析)の追加（浜辺07/08）
     names(dat_graph) <- rev(colnames(res$ssb))[1:(n_retro+1)]  # 図にinputされる結果に名前をつける
   }
 


### PR DESCRIPTION
do_retrospective_vpaでlast.catch.zeroのときに元々のフルデータの結果がグラフに表示されないので修正してみましたので、ご確認していただけますでしょうか？　@KoheiHAMABE さん
あと少し別の話ですが、last.catch.zeroのとき最終年はterminal Fを推定する翌年になっており、この年は図示から省くようにしたほうがmohn rhoとの整合性が取れてわかりやすいように思うのですがいかがでしょうか？たとえば元々のvpaの結果がterminal yearの年が2019年、last.catch.zeroの年が2020年とすると、2019年から1年ずつ削っていったものをプロットしてはどうか？ということです。