### PR TITLE
fix issue 549

### DIFF
--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -205,13 +205,21 @@ backward.calc <- function(caa,naa,M,na,k,min.caa=0.001,p=0.5,plus.group=TRUE,sel
   return(out)
 }
 
-# memo: plus groupオプションに対応させる必要あり(対応させたらメモは削除してください）
-forward.calc <- function(faa,naa,M,na,k){
+
+forward.calc <- function(faa,naa,M,na,k,plus.group=plus.group){
   out <- rep(NA, na[k])
   for (i in 2:(na[k]-1)){
-    out[i] <- naa[i-1,k-1]*exp(-faa[i-1,k-1]-M[i-1,k-1])
+    out[i] <- naa[i-1,k-1]*exp(-faa[i-1,k-1]-M[i-1,k-1]) #最終年の最低年齢より上，最高年齢より下のnaaを計算してる
   }
-  out[na[k]] <- sum(sapply(seq(na[k]-1,max(na[k], na[k-1])), plus.group.eq, naa=naa, faa=faa, M=M, k=k))
+  if (isTRUE(plus.group)){
+    out[na[k]] <- sum(sapply(seq(na[k]-1,max(na[k], na[k-1])), plus.group.eq, naa=naa, faa=faa, M=M, k=k)) #最終年最高年齢のnaa
+  }
+  else
+  {
+    out[na[k]] <- sapply(na[k]-1, plus.group.eq, naa=naa, faa=faa, M=M, k=k)
+  }
+  
+  
   return(out)
 }
 
@@ -982,8 +990,8 @@ if (isTRUE(madara)){
 
     if (isTRUE(tune)){
       if (n.add==1 & !is.na(mean(index[,ny+n.add],na.rm=TRUE))){
-
-        new.naa <- forward.calc(faa,naa,M,na,ny+n.add)
+        
+        new.naa <- forward.calc(faa,naa,M,na,ny+n.add,plus.group=plus.group)
 
         naa[,ny+n.add] <- new.naa
         baa <- naa*waa
@@ -1219,7 +1227,7 @@ if (isTRUE(madara)){
         # next year
 
         if (n.add==1 & is.na(naa[1,ny+n.add])){
-          new.naa <- forward.calc(faa,naa,M,na,ny+n.add)
+          new.naa <- forward.calc(faa,naa,M,na,ny+n.add,plus.group=plus.group)
           if (!is.null(f.new) & !is.null(saa.new)) faa[,ny+n.add] <- f.new*saa.new else faa[,ny+n.add] <- 0
           naa[,ny+n.add] <- new.naa
           baa <- naa*waa

--- a/tests/testthat/test-data.handler.R
+++ b/tests/testthat/test-data.handler.R
@@ -383,6 +383,14 @@ test_that("vpa function (with dummy data) (level 2-3?)",{
   res_vpa_base0_lst0_zen1 <- vpa(vpadat_lst0, tf.year=2007:2009, last.catch.zero = TRUE, 
                                  Pope = TRUE, p.init = 0.5, tune=TRUE, term.F="all", est.method="ml", b.est=FALSE, abund=c("N","N","N","N","N","N"),min.age=c(0,0,0,0,0,0),max.age=c(3,3,0,0,3,3),rec.new=NULL)
   expect_equal(as.numeric(res_vpa_base0_lst0_zen1$naa[1,10]),NA_real_)
+  expect_equal(as.numeric(round(res_vpa_base0_lst0_zen1$naa[,10],2)),c(NA_real_,538.18,25.87,150.63))
+  
+  #   全F推定法: last.catch.zero=TRUEで，rec.new=NULLのとき，plus.group=FALSE
+  res_vpa_base0_lst0_zen11 <- vpa(vpadat_lst0, tf.year=2007:2009, last.catch.zero = TRUE, 
+                                 Pope = TRUE, p.init = 0.5, tune=TRUE, term.F="all", est.method="ml", b.est=FALSE, abund=c("N","N","N","N","N","N"),min.age=c(0,0,0,0,0,0),max.age=c(3,3,0,0,3,3),rec.new=NULL,plus.group=FALSE)
+
+  expect_equal(as.numeric(round(res_vpa_base0_lst0_zen11$naa[,10],2)),c(NA_real_,685.22,86.13,118.49))
+  
   
   #   全F推定法: last.catch.zero=TRUEで，rec.new=1000のとき，最新年の0歳は1000となる
   res_vpa_base0_lst0_zen2 <- vpa(vpadat_lst0, tf.year=2007:2009, last.catch.zero = TRUE, 


### PR DESCRIPTION
対応遅くなりすみません．
last.catch.zero=TRUEのときに，最高齢が+グループでない場合の最終年（catchがある年の翌年）の最高齢のnaaの計算の仕方を修正しました．
https://github.com/ichimomo/frasyr/issues/549
のissueに対応してます
（プルリクのところばかりみてて，issueのところ読んでなかったので，市野川さんのplus_group_issue_vpaブランチを引き継いで修正してしまいました，大丈夫でしょうか）