### PR TITLE
bootSR.plotのレジームありのggpltオプションでエラー

### DIFF
--- a/R/stock_recruit.r
+++ b/R/stock_recruit.r
@@ -1615,7 +1615,8 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
         geom_vline(data=res_boot_par_tibble_summary, mapping = aes(xintercept=value,color=stats),linetype="dashed") +
         scale_color_manual(name="stats",values = plot_col) #+
       #scale_linetype_manual(name="",values = plot_bootsr_linetype) #+ #scale_color_discrete(name="stats",breaks=legend.labels)
-      #boot_par_hist
+
+      print(boot_par_hist)
 
       if (output) ggsave(file = paste0(filename,"_pars.png"), plot=boot_par_hist, width=10, height=10,  units='in')
 
@@ -1717,7 +1718,7 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
       plot_bootsr_linetype <- rep(bootsr_linetype,length(levels(as.factor(res_boot_par_tibble$name))))
 
       regime.num <- length(levels(as.factor(res_boot_par_tibble$regime)))-1
-      boot_par_hist.regime<-list()
+
       for(k in 0:regime.num){
         if (boot.res$input$method=="d") {
           plot_bootsr_title<- paste0("Data Bootstrap regime",k)
@@ -1751,9 +1752,7 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
           geom_vline(data=res_boot_par_tibble_summary, mapping = aes(xintercept=value,color=stats),linetype="dashed") +
           scale_color_manual(name="stats",values = plot_col)
 
-        boot_par_hist.regime[[k+1]] <- boot_par_hist
-
-        #boot_par_hist
+        print(boot_par_hist)
 
         if (output) ggsave(file = paste0(filename,"_regime",k,"_pars.png"), plot=boot_par_hist, width=10, height=10,  units='in')
 
@@ -1851,17 +1850,6 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
       points(pred_data$SSB,pred_data$R,col=2,type="l",lwd=3)
     }
     if (output) dev.off()
-  }
-
-  if (ggplt){
-    if (class(boot.res$input$Res)=="fit.SR"){
-      boot_par_hist
-    }
-    else{
-      for(k in 0:regime.num){
-        boot_par_hist.regime[[k+1]]
-      }
-    }
   }
 
 }

--- a/R/stock_recruit.r
+++ b/R/stock_recruit.r
@@ -1615,6 +1615,8 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
         geom_vline(data=res_boot_par_tibble_summary, mapping = aes(xintercept=value,color=stats),linetype="dashed") +
         scale_color_manual(name="stats",values = plot_col) #+
       #scale_linetype_manual(name="",values = plot_bootsr_linetype) #+ #scale_color_discrete(name="stats",breaks=legend.labels)
+      #boot_par_hist
+
       if (output) ggsave(file = paste0(filename,"_pars.png"), plot=boot_par_hist, width=10, height=10,  units='in')
 
     }
@@ -1705,7 +1707,7 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
 
     if(ggplt){ # plot using ggplot
       res_base = boot.res$input$Res
-
+      N <- boot.res$input$n
       res_boot_par_tibble <- purrr::map_dfr(boot.res[1:N], convert_SR_tibble) %>% dplyr::filter(type=="parameter"&name!="SPR0")
 
       legend.labels <- c("estimated", "CI10", "CI90","mean","median")
@@ -1715,7 +1717,7 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
       plot_bootsr_linetype <- rep(bootsr_linetype,length(levels(as.factor(res_boot_par_tibble$name))))
 
       regime.num <- length(levels(as.factor(res_boot_par_tibble$regime)))-1
-
+      boot_par_hist.regime<-list()
       for(k in 0:regime.num){
         if (boot.res$input$method=="d") {
           plot_bootsr_title<- paste0("Data Bootstrap regime",k)
@@ -1748,6 +1750,11 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
           geom_vline(data=res_boot_par_base, mapping = aes(xintercept=value,color=stats),linetype=base_linetype) +
           geom_vline(data=res_boot_par_tibble_summary, mapping = aes(xintercept=value,color=stats),linetype="dashed") +
           scale_color_manual(name="stats",values = plot_col)
+
+        boot_par_hist.regime[[k+1]] <- boot_par_hist
+
+        #boot_par_hist
+
         if (output) ggsave(file = paste0(filename,"_regime",k,"_pars.png"), plot=boot_par_hist, width=10, height=10,  units='in')
 
       }
@@ -1844,6 +1851,17 @@ bootSR.plot = function(boot.res, CI = 0.8,output = FALSE,filename = "boot",lwd=1
       points(pred_data$SSB,pred_data$R,col=2,type="l",lwd=3)
     }
     if (output) dev.off()
+  }
+
+  if (ggplt){
+    if (class(boot.res$input$Res)=="fit.SR"){
+      boot_par_hist
+    }
+    else{
+      for(k in 0:regime.num){
+        boot_par_hist.regime[[k+1]]
+      }
+    }
   }
 
 }


### PR DESCRIPTION
エラー原因はブートストラップの回数Nをレジームありの時に代入し忘れていたこと。下追記。
https://github.com/fshin3/frasyr/blob/059438df0e8eaae4697c6fb72d799d90e887bf5c/R/stock_recruit.r#L1710

ついでに、output=F, ggplt＝Tでもggplot出力するように変更。なぜかレジームありの時は描画されず。ggplotオブジェクト作成時に、そのオブジェクトを呼び出しても描画されないので、関数の最後に以下のような感じで描画するようにしたんですが、
https://github.com/fshin3/frasyr/blob/059438df0e8eaae4697c6fb72d799d90e887bf5c/R/stock_recruit.r#L1856-L1865
https://github.com/fshin3/frasyr/blob/059438df0e8eaae4697c6fb72d799d90e887bf5c/R/stock_recruit.r#L1754

なんで描画されないのか原因わかります？@ichimomoさん。