### PR TITLE
:bug: Avoid execution error in 3do_projection.r in fraser_tool

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     covr,    
     GGally,
     patchwork,
+    splus2R,
 Suggests:
     knitr,
     rmarkdown,

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -90,8 +90,8 @@ caa.est.mat <- function(naa,saa,waa,M,catch.obs,Pope,set_max1=TRUE,max_exploitat
   # caa.est.mat_wrongで初期値を設定するとはやそう
   tmp <- optimize(tmpfunc,c(-10,log(max_F)),catch.obs=catch.obs,naa=naa,saa=saa,waa=waa,M=M,Pope=Pope,out=FALSE)#,tol=.Machine$double.eps)
   tmp2 <- tmpfunc(logx=tmp$minimum,catch.obs=catch.obs,naa=naa,saa=saa,waa=waa,M=M,Pope=Pope,out=TRUE)
-  realized.catch <- sum(tmp2*waa)
-  if(abs(realized.catch/catch.obs-1)>0.1) warning("expected catch:",catch.obs,", realized catch:",realized.catch)
+  realized.catch <- sum(tmp2*waa, na.rm = TRUE)
+  if(!is.nan(realized.catch/catch.obs) & abs(realized.catch/catch.obs-1)>0.1) warning("expected catch:",catch.obs,", realized catch:",realized.catch)
   return(list(x=exp(tmp$minimum),caa=tmp2,realized.catch=realized.catch, expected.catch=catch.obs))
 }
 

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -90,7 +90,7 @@ caa.est.mat <- function(naa,saa,waa,M,catch.obs,Pope,set_max1=TRUE,max_exploitat
   # caa.est.mat_wrongで初期値を設定するとはやそう
   tmp <- optimize(tmpfunc,c(-10,log(max_F)),catch.obs=catch.obs,naa=naa,saa=saa,waa=waa,M=M,Pope=Pope,out=FALSE)#,tol=.Machine$double.eps)
   tmp2 <- tmpfunc(logx=tmp$minimum,catch.obs=catch.obs,naa=naa,saa=saa,waa=waa,M=M,Pope=Pope,out=TRUE)
-  realized.catch <- sum(tmp2*waa, na.rm = TRUE)
+  realized.catch <- sum(tmp2*waa)
   if(!is.nan(realized.catch/catch.obs) & abs(realized.catch/catch.obs-1)>0.1) warning("expected catch:",catch.obs,", realized catch:",realized.catch)
   return(list(x=exp(tmp$minimum),caa=tmp2,realized.catch=realized.catch, expected.catch=catch.obs))
 }


### PR DESCRIPTION
@ichimomo さん、@fshin3 さん（宛でよいでしょうか。）

下記の問題について修正案を送りますので、ご検討下さいますようお願い申し上げます。

**問題** `frasyr_tool`のYR2021ブランチ`script/3do_projection.r`を実行した際、下記のようなエラーが出ました。
```r
if (abs(realized.catch/catch.obs - 1) > 0.1) warning("expected catch:",  でエラー:
    TRUE/FALSE が必要なところが欠損値です
```

**対応**
`traceback()`で原因を探ったところ、frasyrの`caa.est.mat()`で止まっていることがわかりました（詳しくは下記の補足を参照ください）。

`caa.est.mat()`の`if()`内の処理で realized.catch/catch.obs = NaN あるいは NAになった場合にこのエラーがでているようでしたので、プルリクエストのように修正してみました。ご検討をお願いいたします。