### PR TITLE
issue 682

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -7,6 +7,8 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,7 +8,7 @@ jobs:
   pkgdown:
     runs-on: macOS-latest
     env:
-      GITHUB_PAT: ${{ secrets.FRASYR_PAT }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 

--- a/R/stock_recruit.r
+++ b/R/stock_recruit.r
@@ -2622,7 +2622,7 @@ corSR = function(resSR) {
 #' \item{\code{SB0}}{F=0のときの親魚量}
 #' \item{\code{R0}}{F=0のときの加入量}
 #' \item{\code{B0}}{F=0のときの資源量}
-#' \item{\code{h}}{steepness: BHかRIのときは0.2×SB0のときの加入量がh×R0, HSのときはh=1-b/SB0}}
+#' \item{\code{h}}{steepness: BHかRIのときは0.2×SB0のときの加入量がh×R0, HSのときはh=1-b/SB0}
 #' }
 #' @examples
 #' \dontrun{

--- a/man/calc_steepness.Rd
+++ b/man/calc_steepness.Rd
@@ -30,7 +30,14 @@ calc_steepness(
 \item{plus_group}{最高齢がプラスグループかどうか}
 }
 \value{
-
+以下の要素からなるデータフレーム
+\describe{
+\item{\code{SPR0}}{F=0のときのSPR(この逆数がreplacement lineの傾き)}
+\item{\code{SB0}}{F=0のときの親魚量}
+\item{\code{R0}}{F=0のときの加入量}
+\item{\code{B0}}{F=0のときの資源量}
+\item{\code{h}}{steepness: BHかRIのときは0.2×SB0のときの加入量がh×R0, HSのときはh=1-b/SB0}
+}
 }
 \description{
 Steepness (h) と関連するパラメータ (SB0,R0,B0)を計算する関数


### PR DESCRIPTION
@KoHMB @ichimomo 

Solve #682 

fork先のレポジトリ（JK-junkin/frasyr）で pkgdownのエラーが出ないことを確認しました。merge可能かご確認のほどお願いいたします。:bow:

## 1
- calc_steepness()のroxygen commentsに余計な閉じカッコがあった :arrow_left: **これだけでも解決するかもです。**
- env: で参照する FRASYR_PAT がおそらく有効期限切れの（あるいはfork先の私の手元環境にはない）ため、手元環境にあるGITHUB_TOKENを参照するように変更

【注】GITHUB_TOKENはhttps通信でGitHubを使用しているなら設定を求められるはずです。
:point_right: 参考：https://qiita.com/shiro01/items/e886aa1e4beb404f9038

## 2
- ubuntuのビルドエラーも消しました。YAMLファイルにenv: を追加しました。
:point_right: 上記より、GITHUB_TOKEN --> FRASYR_PAT でも行けるかもしれません。