### PR TITLE
スケトウダラ日本海北部系群の計算を再現できるように修正（issue #715）

### DIFF
--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -330,9 +330,9 @@ abund.extractor <- function(
  }
 
 # if (abund=="N1sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE)
- if (abund=="N1sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]), na.rm=TRUE) #スケトウ日本海北部用
+ if (abund=="N1sj") res <- colSums(naa[1,]*exp(dat$M[1,]), na.rm=TRUE) #スケトウ日本海北部用
 # if (abund=="N0sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE)
- if (abund=="N0sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]*2), na.rm=TRUE) #スケトウ日本海北部用
+ if (abund=="N0sj") res <- colSums(naa[1,]*exp(dat$M[1,]*2), na.rm=TRUE) #スケトウ日本海北部用
 
  if (abund=="F") if (is.null(catch.prop)) res <- colMeans(faa[min.age:max.age,], na.rm=TRUE) else res <- colMeans(catch.prop[min.age:max.age, ]*faa[min.age:max.age,], na.rm=TRUE)
 

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -324,9 +324,16 @@ abund.extractor <- function(
    if (is.null(maa.tune)) ssb <- naa*waa*maa*exp(-p.m*dat$M-p.m*af*faa) else ssb <- naa*waa*maa.tune*exp(-p.m*dat$M-p.m*af*faa)
    res <- colSums(ssb,na.rm=TRUE)
  }
+ if (abund=="SSBmsj"){
+   if (is.null(maa.tune)) ssb <- naa*waa*maa*exp(-p.m*dat$M) else ssb <- naa*waa*maa.tune*exp(-p.m*dat$M) #スケトウ日本海北部用
+   res <- colSums(ssb,na.rm=TRUE)
+ }
 
- if (abund=="N1sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE)
- if (abund=="N0sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]*2),NA), na.rm=TRUE)
+# if (abund=="N1sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE)
+ if (abund=="N1sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE) #スケトウ日本海北部用
+# if (abund=="N0sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE)
+ if (abund=="N0sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE) #スケトウ日本海北部用
+
  if (abund=="F") if (is.null(catch.prop)) res <- colMeans(faa[min.age:max.age,], na.rm=TRUE) else res <- colMeans(catch.prop[min.age:max.age, ]*faa[min.age:max.age,], na.rm=TRUE)
 
  if (link=="log") res <- log(res, base=base)

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -325,14 +325,12 @@ abund.extractor <- function(
    res <- colSums(ssb,na.rm=TRUE)
  }
  if (abund=="SSBmsj"){
-   if (is.null(maa.tune)) ssb <- naa*waa*maa*exp(-p.m*dat$M) else ssb <- naa*waa*maa.tune*exp(-p.m*dat$M) #スケトウ日本海北部用
+   if (is.null(maa.tune)) ssb <- naa*waa*maa*exp(-p.m*dat$M) else ssb <- naa*waa*maa.tune*exp(-p.m*dat$M) 
    res <- colSums(ssb,na.rm=TRUE)
  }
 
-# if (abund=="N1sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE)
- if (abund=="N1sj") res <- colSums(naa[1,]*exp(dat$M[1,]), na.rm=TRUE) #スケトウ日本海北部用
-# if (abund=="N0sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE)
- if (abund=="N0sj") res <- colSums(naa[1,]*exp(dat$M[1,]*2), na.rm=TRUE) #スケトウ日本海北部用
+ if (abund=="N1sj") res <- colSums(naa[1,]*exp(dat$M[1,]), na.rm=TRUE) 
+ if (abund=="N0sj") res <- colSums(naa[1,]*exp(dat$M[1,]*2), na.rm=TRUE) 
 
  if (abund=="F") if (is.null(catch.prop)) res <- colMeans(faa[min.age:max.age,], na.rm=TRUE) else res <- colMeans(catch.prop[min.age:max.age, ]*faa[min.age:max.age,], na.rm=TRUE)
 

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -330,7 +330,7 @@ abund.extractor <- function(
  }
 
 # if (abund=="N1sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE)
- if (abund=="N1sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE) #スケトウ日本海北部用
+ if (abund=="N1sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1])), na.rm=TRUE) #スケトウ日本海北部用
 # if (abund=="N0sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE)
  if (abund=="N0sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE) #スケトウ日本海北部用
 

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -330,9 +330,9 @@ abund.extractor <- function(
  }
 
 # if (abund=="N1sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE)
- if (abund=="N1sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1])), na.rm=TRUE) #スケトウ日本海北部用
+ if (abund=="N1sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]), na.rm=TRUE) #スケトウ日本海北部用
 # if (abund=="N0sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE)
- if (abund=="N0sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE) #スケトウ日本海北部用
+ if (abund=="N0sj") res <- colSums(naa[1,-1]*exp(dat$M[1,-1]*2), na.rm=TRUE) #スケトウ日本海北部用
 
  if (abund=="F") if (is.null(catch.prop)) res <- colMeans(faa[min.age:max.age,], na.rm=TRUE) else res <- colMeans(catch.prop[min.age:max.age, ]*faa[min.age:max.age,], na.rm=TRUE)
 


### PR DESCRIPTION
issueにも書きましたが、スケトウダラ日本海北部系群のVPAをrvpaで再現するにあたり、必要なコードをrvpa.rのabund.extractor関数に追加させて頂きたく、プルリクエストします。

rvpa.rのabund.extractor関数において、以下を追加します；
`if (abund=="SSBmsj"){`
`if (is.null(maa.tune)) ssb <- naa*waa*maa*exp(-p.m*dat$M) else ssb <- naa*waa*maa.tune*exp(-p.m*dat$M)`
`res <- colSums(ssb,na.rm=TRUE)`
`}`

また、以下の本系群用のオプションも、少し変なところがあるので、少し修正させて下さい；
（修正前）
`if (abund=="N1sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]),NA), na.rm=TRUE)`
`if (abund=="N0sj") res <- colSums(cbind(naa[1,-1]*exp(dat$M[1,-1]*2)), na.rm=TRUE)　`
（修正後）
`if (abund=="N1sj") res <- colSums(naa[1,]*exp(dat$M[1,]), na.rm=TRUE)`
`if (abund=="N0sj") res <- colSums(naa[1,]*exp(dat$M[1,]*2), na.rm=TRUE)`

どうぞよろしくお願いします。