### PR TITLE
add option of period_extra in calculate_all_pm

### DIFF
--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -441,5 +441,5 @@ test_that("calculate_all_pm", {
   all_pm2 <- calculate_all_pm(res_future, period_extra=list(2:6))
 
   expect_equal(all_pm1, all_pm2)
-  expect_equal(nrow(all_pm)<nrow(all_pm1)
+  expect_equal(nrow(all_pm)<nrow(all_pm1), TRUE)
 })

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -429,4 +429,17 @@ test_that("calculate_all_pm", {
   res_future <- data_future_test$data %>% future_vpa()
   all_pm <- calculate_all_pm(res_future)
   expect_equal(is_tibble(all_pm),TRUE)
+
+  # 暫定テスト(1:10までの出力が一致するか）
+  c(`2017` = 710.22, `2018` = 447.9, `2019` = 470.5, `2020` = 1000, 
+    `2021` = 2000, `2022` = 941.73, `2023` = 954.37, `2024` = 918.09, 
+    `2025` = 897.95, `2026` = 895.95) %>%
+      expect_equal(round(all_pm$value[1:10],2))
+
+  # 引数extra_periodの確認
+  all_pm1 <- calculate_all_pm(res_future, period_extra=list(2:6, 0:4))
+  all_pm2 <- calculate_all_pm(res_future, period_extra=list(2:6))
+
+  expect_equal(all_pm1, all_pm2)
+  expect_equal(nrow(all_pm)<nrow(all_pm1)
 })


### PR DESCRIPTION
calculate_all_pmにperiod_extraオプションを追加．カスタマイズされた特殊な期間でリスク表を計算したいときに使う