### PR TITLE
add box.padding option for plot_SR

### DIFF
--- a/R/graphics.r
+++ b/R/graphics.r
@@ -343,7 +343,7 @@ plot_SRdata <- function(SRdata, type=c("classic","gg")[1]){
 
 plot_SR <- function(SR_result,refs=NULL,xscale=1000,xlabel="千トン",yscale=1,ylabel="尾",
                     labeling.year=NULL,add.info=TRUE, recruit_intercept=0,
-                    plot_CI=FALSE, CI=0.9, shape_custom=c(21,3),
+                    plot_CI=FALSE, CI=0.9, shape_custom=c(21,3),box.padding=0,
                     add_graph=NULL){
 
   if(is.null(refs$Blimit) && !is.null(refs$Blim)) refs$Blimit <- refs$Blim
@@ -450,9 +450,12 @@ plot_SR <- function(SR_result,refs=NULL,xscale=1000,xlabel="千トン",yscale=1,
     geom_point(data=dplyr::filter(alldata,type=="obs"),
                aes(y=R,x=SSB,shape=weight),fill="white") +
     scale_shape_manual(values = shape_custom) +
+      #    ggrepel::geom_text_repel(data=dplyr::filter(alldata,type=="obs"),
+      #                             segment.alpha=0.5,nudge_y=5,
+      #                             aes(y=R,x=SSB,label=pick.year)) +
     ggrepel::geom_text_repel(data=dplyr::filter(alldata,type=="obs"),
-                             segment.alpha=0.5,nudge_y=5,
-                             aes(y=R,x=SSB,label=pick.year)) +
+                             box.padding=box.padding,segment.color="gray",nudge_y=5,
+                             aes(y=R,x=SSB,label=pick.year)) +    
     theme_bw(base_size=14)+
     theme(legend.position = 'none') +
     theme(panel.grid = element_blank()) +

--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -42,7 +42,7 @@ test_that("plot_SRdata", {
 
 test_that("SRplot_gg", {
   g1 <- SRplot_gg(res_sr_HSL1)
-  g2 <- SRplot_gg(res_sr_HSL2)
+  g2 <- SRplot_gg(res_sr_HSL2, box.padding=1)
   expect_equal(class(g1)[1],"gg")
   expect_equal(class(g2)[1],"gg")
 })


### PR DESCRIPTION
plot_SRにbox.paddingオプションを追加．デフォルトは０（今まで通りのプロット）だが，ここの数字を大きくすると，指し示す点とラベルの間に線が引かれて，ラベルと点が重ならないように調整される