### PR TITLE
:wrench: 共通のローカル開発環境を立てられるようにする

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,1 @@
+devtools::load_all()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rocker/verse:4.2.2
+
+COPY . frasyr
+
+RUN R -e "devtools::install_local('frasyr')"
+
+ENV EDITOR_FOCUS_DIR="/home/rstudio/frasyr"
+
+RUN mkdir -p $EDITOR_FOCUS_DIR
+
+USER 0
+RUN echo "session-default-working-dir=$EDITOR_FOCUS_DIR" >> /etc/rstudio/rsession.conf && \
+    echo "session-default-new-project-dir=$EDITOR_FOCUS_DIR" >> /etc/rstudio/rsession.conf

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include .env
 
-CR := some-registry
+CR := rindrics
 GIT_VERSION := $(shell git describe --tags --always --dirty)
 BRANCH := $(shell git symbolic-ref --short HEAD)
 VERSION := latest

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 include .env
 
 CR := some-registry
-VERSION := $(shell git describe --tags --always --dirty)
+GIT_VERSION := $(shell git describe --tags --always --dirty)
 BRANCH := $(shell git symbolic-ref --short HEAD)
+VERSION := latest
 
 .PHONY: run
 run:
@@ -10,18 +11,18 @@ run:
 	-e PASSWORD=frasyr \
 	-v $(PWD):/home/rstudio/frasyr \
 	-p 8787:8787 \
-	$(CR)/frasyr-dev:$(FRASYR_VERSION)
+	$(CR)/frasyr-dev:$(VERSION)
 
 .PHONY: build
 build:
 	docker image build \
 	-t $(CR)/frasyr-dev:$(BRANCH) \
-	-t $(CR)/frasyr-dev:$(VERSION) \
+	-t $(CR)/frasyr-dev:$(GIT_VERSION) \
 	-t $(CR)/frasyr-dev:latest \
 	.
 
 .PHONY: push
 push:
 	docker image push $(CR)/frasyr-dev:$(BRANCH)
-	docker image push $(CR)/frasyr-dev:$(VERSION)
+	docker image push $(CR)/frasyr-dev:$(GIT_VERSION)
 	docker image push $(CR)/frasyr-dev:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+include .env
+
+CR := ghcr.io/fra-dev-ops-bu
+VERSION := $(shell git describe --tags --always --dirty)
+BRANCH := $(shell git symbolic-ref --short HEAD)
+
+.PHONY: run
+run:
+	docker run --rm -it \
+	-e PASSWORD=frasyr \
+	-v $(PWD):/home/rstudio/frasyr \
+	-p 8787:8787 \
+	$(CR)/frasyr-dev:$(FRASYR_VERSION)
+
+.PHONY: build
+build:
+	docker image build \
+	-t $(CR)/frasyr-dev:$(BRANCH) \
+	-t $(CR)/frasyr-dev:$(VERSION) \
+	-t $(CR)/frasyr-dev:latest \
+	.
+
+.PHONY: push
+push:
+	docker image push $(CR)/frasyr-dev:$(BRANCH)
+	docker image push $(CR)/frasyr-dev:$(VERSION)
+	docker image push $(CR)/frasyr-dev:latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include .env
 
-CR := ghcr.io/fra-dev-ops-bu
+CR := some-registry
 VERSION := $(shell git describe --tags --always --dirty)
 BRANCH := $(shell git symbolic-ref --short HEAD)
 


### PR DESCRIPTION
## 背景
- 下記 PR の CI 失敗について調査するために Ubuntu 環境が必要だった
  - #756 
- 公式に配布されている環境（https://rocker-project.org/ ）を使うことにした
- 上記を手軽に使えるようにすれば開発チームにとっても役立つと思った

## やったこと

- 公式の Rstudio Docker イメージを使った開発環境の構築を手軽にできるようにしました
- 環境の立ち上げ手順を [wiki として追加しました](https://github.com/ichimomo/frasyr/wiki/%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E9%96%8B%E7%99%BA%E7%92%B0%E5%A2%83%E3%81%AE%E6%A7%8B%E7%AF%89)

## やらなかったこと

- Docker image の build & push 方法の解説
