### PR TITLE
Fix calculate all pm

### DIFF
--- a/R/utilities.r
+++ b/R/utilities.r
@@ -3229,19 +3229,19 @@ calculate_all_pm <- function(res_future, SBtarget=-1, SBlimit=-1, SBban=-1, SBmi
                     max_value = function(x){
                         if(all(is.na(x))) NA else max(x, na.rm=TRUE)
                     },
-                    prob_target_any  = function(x) ifelse(sum(x<SBtarget,na.rm=TRUE)>0,1,0),
+                    prob_target_any  = function(x) ifelse(sum(x<SBtarget,na.rm=FALSE)>0,1,0),
                     prob_limit_any  = function(x){
                       if(type=="PM") SBlimit <- rep(1,length(x))
-                      ifelse(sum(x<SBlimit,na.rm=TRUE)>0,1,0)
+                      ifelse(sum(x<SBlimit,na.rm=FALSE)>0,1,0)
                     },
                     prob_half_any  = function(x) ifelse(sum(x[-1]<0.5*x[-length(x)])>0,1,0),
                     prob_ban_any    = function(x){
                       if(type=="PM") SBban <- rep(1,length(x))                      
-                      ifelse(sum(x<SBban,na.rm=TRUE)>0,1,0)
+                      ifelse(sum(x<SBban,na.rm=FALSE)>0,1,0)
                     },
                     prob_min_any    = function(x){
                       if(type=="PM") SBmin <- rep(1,length(x))                      
-                      ifelse(sum(x<SBmin,na.rm=TRUE)>0,1,0)
+                      ifelse(sum(x<SBmin,na.rm=FALSE)>0,1,0)
                     })
 
   mat_list <- lst(ssb=ssb_mat, biom=biom_mat, catch=catch_mat)

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -3229,6 +3229,8 @@ calculate_all_pm <- function(res_future, SBtarget=-1, SBlimit=-1, SBban=-1, SBmi
                     max_value = function(x){
                         if(all(is.na(x))) NA else max(x, na.rm=TRUE)
                     },
+                    # 以下、na.rm=FALSEに変更。PMで全てのデータがNAであった場合、na.rm=TRUEとすると0という数字が入ってしまうので、PMで使うならここはFALSEとすべき
+                    # ただし、一部だけNAが入るような場合にはどうすべきか？そういう事例がでたときに要検討
                     prob_target_any  = function(x) ifelse(sum(x<SBtarget,na.rm=FALSE)>0,1,0),
                     prob_limit_any  = function(x){
                       if(type=="PM") SBlimit <- rep(1,length(x))


### PR DESCRIPTION
calculate_all_pmをPM用に流用する場合、すべての列にNAが入るケースがあり、その場合にはna.rm=TRUEだと良くない（NAのデータがカウントされてしまう）ので、FALSEに変更