### PR TITLE
Delete broken & unused .github/workflows/workflow.yml

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,9 +1,0 @@
-steps:
-- uses: actions/checkout@master
-- uses: codecov/codecov-action@v2
-  with:
-    files: ./coverage1.xml,./coverage2.xml # optional
-    flags: unittests # optional
-    name: codecov-umbrella # optional
-    fail_ci_if_error: true # optional (default = false)
-    verbose: true # optional (default = false)


### PR DESCRIPTION
シンタックスエラーで[必ず失敗](https://github.com/ichimomo/frasyr/actions/workflows/workflow.yml)するワークフロー定義が残っていたので削除します。
- 当該ファイルの内容はCodeCovに関するもののようで、カバレッジ計測は[別ワークフロー](https://github.com/ichimomo/frasyr/actions/runs/11381418489/workflow)でできていそうだったので削除しても問題なさそうと判断しました
