### PR TITLE
Fix typo on build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # frasyr
-[![Build status](https://github.com/ichimomo/frasyr/actions/workflows/check-standard.yml/badge.svg)](https://github.com/ichimomo/frasyr/actions/workflows/check-standard.yml)
+[![Build status](https://github.com/ichimomo/frasyr/actions/workflows/check-standard.yaml/badge.svg)](https://github.com/ichimomo/frasyr/actions/workflows/check-standard.yaml)
   [![Codecov test coverage](https://codecov.io/gh/ichimomo/frasyr/branch/dev/graph/badge.svg)](https://codecov.io/gh/ichimomo/frasyr?branch=dev)
 - Fisheries Research Agency (FRA) provides the method for calculating sustainable yield (SY) with R
 - VPAを用いた資源量推定と，その推定結果をもとにしてMSYを基礎とした目標管理基準値を計算するためのRのパッケージです．開発途中のものであること，ご承知おきください．


### PR DESCRIPTION
すみません、バッジの URL に typo があったので修正します

### before

![image](https://github.com/user-attachments/assets/d17f3b9a-3314-4863-b44a-91bcdcd114b8)


### after

![image](https://github.com/user-attachments/assets/f24059e0-04a6-4944-91e0-93091fa7d6fe)
