### PR TITLE
remove nudge_y of geom_text_repel in plot_SR

### DIFF
--- a/R/graphics.r
+++ b/R/graphics.r
@@ -376,7 +376,7 @@ plot_SRdata <- function(SRdata, type=c("classic","gg")[1]){
 
 plot_SR <- function(SR_result,refs=NULL,xscale=1000,xlabel="千トン",yscale=1,ylabel="尾",
                     labeling.year=NULL,add.info=TRUE, recruit_intercept=0,
-                    plot_CI=FALSE, CI=0.9, shape_custom=c(21,3),box.padding=0,
+                    plot_CI=FALSE, CI=0.9, shape_custom=c(21,3),box.padding=0.4,
                     add_graph=NULL, last_year_color=0){
 
   if(is.null(refs$Blimit) && !is.null(refs$Blim)) refs$Blimit <- refs$Blim
@@ -470,13 +470,15 @@ plot_SR <- function(SR_result,refs=NULL,xscale=1000,xlabel="千トン",yscale=1,
                 color="deepskyblue3",lty=3,n=5000)
   }
 
+  #nudge_y_value <- min(max(alldata$R)/5,5)
+
   g1 <- g1+geom_path(data=dplyr::filter(alldata,type=="obs"),
                        aes(y=R,x=SSB),color=gray(0.6)) +
     geom_point(data=dplyr::filter(alldata,type=="obs"),
                aes(y=R,x=SSB,shape=weight, fill=last_years_fill),color="black") +
     scale_shape_manual(values = shape_custom) +
     ggrepel::geom_text_repel(data=dplyr::filter(alldata,type=="obs"),
-                             box.padding=box.padding,segment.color="gray",nudge_y=5,
+                             box.padding=box.padding,segment.color="gray",#nudge_y=nudge_y_value,
                              aes(y=R,x=SSB,label=pick.year)) +
     theme_bw(base_size=14)+
     theme(legend.position = 'none') +

--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -44,10 +44,13 @@ test_that("plot_SRdata", {
 })
 
 test_that("SRplot_gg", {
+    
   g1 <- plot_SR(res_sr_HSL1)
   g2 <- plot_SR(res_sr_HSL2, box.padding=1)
+  g3 <- plot_SR(res_sr_HSL1, yscale=100000000, ylabel="億尾")  
   expect_equal(class(g1)[1],"gg")
   expect_equal(class(g2)[1],"gg")
+  
 })
 
 test_that("compare_SRfit",{


### PR DESCRIPTION
geom_text_repel のnudge_y＝５オプションを削除。nudge_yは相対値ではなく絶対値でスケーリングされるため、ｙ軸の範囲が非常に小さい場合、変なことになってしまう。逆に、ｙ軸の範囲がもっと広い場合に、 nudge=5と決め打ちで与えてもほとんど意味がない。テキストの位置は、相対的な調整が可能なbox.paddingで調整できると思うので、nudge=5の記述を削除。
ただ、これで再生産関係の図の見え方が他の種で大きくかわってしまうので、年内は別ブランチとして運用し、年度が替わるタイミングで本体に取り込む

#886 