### PR TITLE
revert setting of plus_age

### DIFF
--- a/R/future.r
+++ b/R/future.r
@@ -660,7 +660,7 @@ future_vpa <- function(tmb_data,
           res_future$HCR_realized[i,j,"Fratio"] <- res_future$HCR_realized[i,j-1,"Fratio"]
         }
         else{
-          tmp <- 1:tmb_data$plus_age # res_future$naa[,i,j]>0
+          tmp <- res_future$naa[,i,j]>0 # 1:tmb_data$plus_age # 
           res_future$HCR_realized[i,j,"Fratio"] <-
             calc_Fratio(faa=res_future$faa[tmp,i,j],
                         waa=res_future$waa[tmp,i,j],


### PR DESCRIPTION
- SPRを計算するときのplus groupの年齢について，昔何らかの理由で　'res_future$naa[,i,j]>0' 　から '1:tmb_data$plus_age' に変更したが，それだと，プラスグループが途中で変わる場合に不具合があるので元に戻した
- なぜ'1:tmb_data$plus_age'に変えた理由を思い出せないので，戻したことでなにか不具合がでるかもしれないが，いちおう，frasyrとfrasyr_toolのテストは両方とも通ったので，とりあえず戻しておく