### PR TITLE
Fix rvpa tmb m pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ tests/testthat/tmp.pdf
 tests/testthat/vpa.csv
 tests/testthat/vpa.pdf
 .positai
+
+rvpa_tmb.cpp
+rvpa_tmb.dll
+rvpa_tmb.o

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Depends: R (>= 4.0.0)
 License: GPL (>=3)
 Encoding: UTF-8
 LazyData: true
+RoxygenNote: 7.3.3
 Imports:
     ggplot2,
     purrr,
@@ -41,4 +42,3 @@ Suggests:
     covr,
     mvtnorm
 VignetteBuilder: knitr
-Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,6 @@ Depends: R (>= 4.0.0)
 License: GPL (>=3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.3
 Imports:
     ggplot2,
     purrr,
@@ -42,3 +41,4 @@ Suggests:
     covr,
     mvtnorm
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/inst/executable/rvpa_tmb.cpp
+++ b/inst/executable/rvpa_tmb.cpp
@@ -349,8 +349,8 @@ Type objective_function<Type>::operator() ()
       // sigma(k) = pow(sigma(k), Type(0.5));
     }
     for (int k=0;k<K;k++){
-      // f += 0.5*nI(k)*(1+log(2*PI))+0.5*nI(k)*(log(sigma2(k))-log(nI(k)));
-      f += Type(0.5)*nI(k)*log(Type(2.0)*PI*sigma(k))+Type(0.5)*sigma2(k)/sigma(k);
+      // f += 0.5*nI(k)*(1+log(2*M_PI))+0.5*nI(k)*(log(sigma2(k))-log(nI(k)));
+      f += Type(0.5)*nI(k)*log(Type(2.0)*M_PI*sigma(k))+Type(0.5)*sigma2(k)/sigma(k);
     }
   }
   f *= (1-lambda);


### PR DESCRIPTION
πを使うのに、PIではなく、M_PIにしないとコンパイルできないようになってしまっていたので、修正しました。
