### PR TITLE
chore: configure Renovate to keep dependencies up-to-date

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 #v2
 
-      - uses: r-lib/actions/setup-pandoc@4f58f8ffa872cbd4cb016c51ec497fdbe0a02711 #2.11.4
+      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 #2.11.4
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 #v2
         with:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,30 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+      timezone: 'Asia/Tokyo'
+  workflow_dispatch:
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: info
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: 'false'
+          RENOVATE_FORK_PROCESSING: enabled

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,15 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:base",
+    ":disableDependencyDashboard",
+  ],
+  timezone: "Asia/Tokyo",
+  enabledManagers: ["github-actions"],
+  "github-actions": {
+    enabled: true,
+    pinDigests: true,
+    automerge: false,
+    labels: ["renovate"],
+  },
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,10 +6,16 @@
   ],
   timezone: "Asia/Tokyo",
   enabledManagers: ["github-actions"],
-  "github-actions": {
-    enabled: true,
-    pinDigests: true,
-    automerge: false,
-    labels: ["renovate"],
-  },
+  packageRules: [
+    {
+      description: "GitHub Actions configuration",
+      matchManagers: ["github-actions"],
+      pinDigests: true,
+      automerge: false,
+      labels: ["renovate"],
+      schedule: [
+        "at 21:40 on Tuesday",
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
依存ツールを自動更新するために Renovate を導入します。

## 背景

- 複数の GitHub Actions workflow で依存ツールの deprecated 警告が出ている（[一例](https://github.com/ichimomo/frasyr/actions/runs/32141430647)）。
- 依存ツールの更新を怠るとセキュリティリスクにつながるが、frasyr 開発の本質からは外れるため、あまり労力をかけたくない
- 依存ツールの更新を支援する仕組みが欲しい

→ [Renovate](https://github.com/renovatebot/renovate) を利用して依存ツールを更新する PR を作成してもらう

## 変更内容

- `renovate.json5`: 利用している GitHub Actions を自動更新するための設定
  - automerge は無効にしてあるので、Renovate が作った PR は都度手動でマージする必要がある
- `.github/workflows/renovate.yaml`: Renovate を定期実行するためのワークフロー定義
  - [mend.io で実行する方法](https://github.com/apps/renovate)と異なり、実行タイミングをこのリポジトリで制御できる
- `.github/workflows/pkgdown.yaml`: `setup-pandoc` の commit SHA がバージョンコメントの `2.11.4` と別物だったため、tag `v2.11.4` の実体に修正

## マージ前に必要な設定

1. [こちら](https://github.com/settings/tokens/new)から classic タイプの PAT を作り、トークンの値を控えておく
   - スコープは `public_repo` と `workflow`（workflow ファイルを更新するため必須）
2. [repo secret 作成画面](https://github.com/ichimomo/frasyr/settings/secrets/actions/new) を開き、下記を設定して保存する
   - Name: `RENOVATE_TOKEN`
   - Secret: 手順 `1.` で控えた PAT の値

## 動作確認

- fork（rindrics/frasyr）で[手動実行](https://github.com/rindrics/frasyr/actions/runs/32150751448)し、[digest 固定の PR が作られる](https://github.com/rindrics/frasyr/pull/16)ことを確認済み